### PR TITLE
채팅 도메인 및 기본 메시지 구조 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
 
+    // 채팅 관련 의존성 추가
+    implementation 'org.springframework.boot:spring-boot-starter-websocket'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+
 
     //    시큐리티 의존성
     //    implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatMessage.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatMessage.java
@@ -1,0 +1,38 @@
+package com.multi.mlpenterpriseapprovalsystem.chat.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+
+/**
+ * 채팅 메세지 컬렉션 (MongoDB)
+ *
+ * @author : 김승기
+ * @filename : ChatMessage
+ * @since : 2025. 12. 16. 화요일
+ */
+@Document(collection = "chat_message")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ChatMessage {
+
+    @Id
+    private String id;
+
+    private String roomId;
+
+    private Long senderId;
+    private String senderName;
+
+    private String content;
+    private MessageType type; // TEXT, IMAGE, SYSTEM
+
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatRoom.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatRoom.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * Please explain the class!!!
+ * 채팅방 엔티티
  *
  * @author : 김승기
  * @filename : ChatRoom

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatRoomMember.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatRoomMember.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 /**
- * Please explain the class!!!
+ * 채팅방 멤버 엔티티
  *
  * @author : 김승기
  * @filename : ChatRoomMember

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/MessageType.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/MessageType.java
@@ -1,7 +1,7 @@
 package com.multi.mlpenterpriseapprovalsystem.chat.domain;
 
 /**
- * Please explain the class!!!
+ * 채팅 메세지 타입 ENUM
  *
  * @author : 김승기
  * @filename : MessageType

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/MessageType.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/MessageType.java
@@ -1,0 +1,12 @@
+package com.multi.mlpenterpriseapprovalsystem.chat.domain;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : 김승기
+ * @filename : MessageType
+ * @since : 2025. 12. 16. 화요일
+ */
+public enum MessageType {
+    TEXT, IMAGE, SYSTEM
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/repository/ChatMessageRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import java.util.List;
 
 /**
- * Please explain the class!!!
+ * 채팅 컬렉션 접근 repository
  *
  * @author : 김승기
  * @filename : ChatMessageRepository

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/repository/ChatMessageRepository.java
@@ -1,0 +1,21 @@
+package com.multi.mlpenterpriseapprovalsystem.chat.repository;
+
+import com.multi.mlpenterpriseapprovalsystem.chat.domain.ChatMessage;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+/**
+ * Please explain the class!!!
+ *
+ * @author : 김승기
+ * @filename : ChatMessageRepository
+ * @since : 2025. 12. 16. 화요일
+ */
+public interface ChatMessageRepository
+        extends MongoRepository<ChatMessage, String> {
+
+    List<ChatMessage> findByRoomIdOrderByCreatedAtDesc(
+            String roomId, Pageable pageable);
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 작업 내용
- 채팅 메시지 도메인(ChatMessage) 설계
- 메시지 타입(MessageType) 정의
- MongoDB 기반 메시지 저장 구조 추가
- 채팅 메시지 조회를 위한 기본 Repository 구현
- 의존성 (websocket, redis, mongoDB 추가)

## 작업 목적
- 채팅 기능 구현을 위한 핵심 도메인 모델 정의
- 데이터 구조 확립

## 비고
- 실시간 WebSocket 및 Redis Pub/Sub 연동은 후속 이슈에서 진행 예정
- 메시지 조회 로직은 기본 구조만 구현

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
