### PR TITLE
feat: 사업자등록번호 인증 기능 구현

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/auth/controller/AuthController.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/auth/controller/AuthController.java
@@ -43,6 +43,20 @@ public class AuthController {
                 .body(response);
     }
 
+    @PostMapping("/companies/verify-brn")
+    public ResponseEntity<ResponseDto<Boolean>> verifyBrn(@RequestParam(name = "brn") String brn) {
+
+        if (authService.isRegisteredBusiness(brn)) {
+            return ResponseEntity
+                    .status(HttpStatus.OK)
+                    .body(new ResponseDto<>(HttpStatus.OK, "인증에 성공하였습니다.", true));
+        } else {
+            // 200 OK를 보내되 결과값만 false로 주거나, 400 에러를 보낼 수 있습니다.
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(new ResponseDto<>(HttpStatus.BAD_REQUEST, "유효하지 않은 사업자번호입니다.", false));
+        }
+    }
+
     @PostMapping("/companies/login")
     public ResponseEntity<ResponseDto<ResTokenDto>> loginCompany(@RequestBody ReqCompanyLoginDto reqCompanyLoginDto, HttpServletResponse response) {
         ResTokenDto token = authService.loginCompany(reqCompanyLoginDto, response);

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/auth/service/AuthService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/auth/service/AuthService.java
@@ -2,6 +2,7 @@ package com.multi.mlpenterpriseapprovalsystem.auth.service;
 
 import com.multi.mlpenterpriseapprovalsystem.auth.dto.CustomUser;
 import com.multi.mlpenterpriseapprovalsystem.common.ResponseDto;
+import com.multi.mlpenterpriseapprovalsystem.common.api.nts.service.BusinessVerificationService;
 import com.multi.mlpenterpriseapprovalsystem.common.enums.RoleType;
 import com.multi.mlpenterpriseapprovalsystem.common.exception.CustomException;
 import com.multi.mlpenterpriseapprovalsystem.common.exception.ErrorCode;
@@ -43,10 +44,17 @@ public class AuthService {
     private final CompanyRepository companyRepository;
     private final StorageService storageService;
     private final SubscriptionRepository subscriptionRepository;
+    private final BusinessVerificationService businessVerificationService;
+
+    public boolean isRegisteredBusiness(String brn) {
+        if (!businessVerificationService.isRegisteredBusiness(brn)) {
+            throw new CustomException(ErrorCode.INVALID_BRN);
+        }
+        return true;
+    }
 
     public ResponseDto<Void> signUpCompany(ReqCompanySignupDto reqCompanySignupDto, MultipartFile logo) {
 
-        // 사업자등록번호 검증 API 추가할 예정
 
         // 1) 이메일 중복 체크
         if (companyRepository.existsByEmail(reqCompanySignupDto.getEmail())) {
@@ -78,7 +86,7 @@ public class AuthService {
                 reqCompanySignupDto.getComId(),
                 reqCompanySignupDto.getComName(),
                 reqCompanySignupDto.getEmail(),
-                passwordEncoder.encode(encodedPwd),
+                encodedPwd,
                 reqCompanySignupDto.getBrn(),
                 reqCompanySignupDto.getAddr(),
                 imgUrl,

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/auth/service/AuthService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/auth/service/AuthService.java
@@ -78,7 +78,7 @@ public class AuthService {
                 reqCompanySignupDto.getComId(),
                 reqCompanySignupDto.getComName(),
                 reqCompanySignupDto.getEmail(),
-                passwordEncoder.encode(reqCompanySignupDto.getPwd()),
+                passwordEncoder.encode(encodedPwd),
                 reqCompanySignupDto.getBrn(),
                 reqCompanySignupDto.getAddr(),
                 imgUrl,

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/api/nts/dto/NtsStatusDto.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/api/nts/dto/NtsStatusDto.java
@@ -1,0 +1,43 @@
+package com.multi.mlpenterpriseapprovalsystem.common.api.nts.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 국세청 사업자 상태 조회 API용 DTO
+ * 
+ * @filename    : NtsStatusDto
+ * @author      : 권지영
+ * @since       : 2025. 12. 19. 금요일
+ */
+public class NtsStatusDto {
+
+    @Getter @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Request {
+        private List<String> b_no; // 사업자번호 목록 (배열 형태)
+    }
+
+    @Getter @Setter
+    public static class Response {
+        private String status_code;
+        private Integer request_cnt;
+        private Integer match_cnt;
+        private List<Data> data;
+
+        @Getter
+        @Setter
+        public static class Data {
+            private String b_no;       // 사업자번호
+            private String b_stt;      // 납세자상태 (계속사업자/휴업자/폐업자)
+            private String b_stt_cd;   // 상태코드 (01/02/03)
+            private String tax_type;   // 과세유형 (가장 중요: "국세청에 등록되지 않은..." 메시지 체크용)
+            private String end_dt;     // 폐업일
+        }
+    }
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/api/nts/service/BusinessVerificationService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/api/nts/service/BusinessVerificationService.java
@@ -1,0 +1,62 @@
+package com.multi.mlpenterpriseapprovalsystem.common.api.nts.service;
+
+import com.multi.mlpenterpriseapprovalsystem.common.api.nts.dto.NtsStatusDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Collections;
+
+/**
+ * 사업자등록번호 검증 서비스 (외부 api 통신)
+ * 
+ * @filename    : BusinessVerificationService
+ * @author      : 권지영
+ * @since       : 2025. 12. 19. 금요일
+ */
+@Service
+@Slf4j
+public class BusinessVerificationService {
+
+    @Value("${nts.api.service-key}")
+    private String serviceKey;
+
+    private final String API_URL = "https://api.odcloud.kr/api/nts-businessman/v1/status?serviceKey=";
+
+    /**
+     * 사업자등록번호 존재 여부 확인
+     * @param brn 사업자등록번호
+     * @return 등록된 번호라면 true, 아니면 false
+     */
+    public boolean isRegisteredBusiness(String brn) {
+        RestTemplate restTemplate = new RestTemplate();
+
+        // 1. 하이픈 제거 (숫자 10자리로 변환)
+//        String cleanBrn = brn.replaceAll("-", "");
+
+        // 2. 요청 바디 구성
+        NtsStatusDto.Request request = new NtsStatusDto.Request(Collections.singletonList(brn));
+
+        try {
+            // 3. 국세청 API 호출 (POST)
+            NtsStatusDto.Response response = restTemplate.postForObject(
+                    API_URL + serviceKey,
+                    request,
+                    NtsStatusDto.Response.class
+            );
+
+            if (response != null && response.getData() != null && !response.getData().isEmpty()) {
+                String taxType = response.getData().get(0).getTax_type();
+                log.info("사업자 번호 [{}] 조회 결과: {}", brn, taxType);
+
+                // "등록되지 않은" 이라는 문구가 포함되어 있지 않으면 유효한 번호로 간주
+                return !taxType.contains("등록되지 않은");
+            }
+        } catch (Exception e) {
+            log.error("국세청 API 호출 실패: {}", e.getMessage());
+        }
+
+        return false;
+    }
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/exception/ErrorCode.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/exception/ErrorCode.java
@@ -19,6 +19,7 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "DUPLICATE_EMAIL", "이미 사용 중인 이메일입니다"),
     DUPLICATE_COMID(HttpStatus.CONFLICT, "DUPLICATE_COMID", "이미 사용 중인 회사 코드입니다"),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "INVALID_PASSWORD", "비밀번호가 일치하지 않습니다"),
+    INVALID_BRN(HttpStatus.BAD_REQUEST, "INVALID_BRN", "유효하지 않은 사업자등록번호입니다"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "로그인이 필요합니다"),
 
     //요금제 관련

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/employee/domain/Employee.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/employee/domain/Employee.java
@@ -80,13 +80,18 @@ public class Employee {
     private Boolean isDeleted = false; // 퇴사여부 // default = false
 
     @Column(nullable = false, length = 1)
-    private String atte; // 근태(출장 = b , 휴가 = v, 근무 중 = c) // default = c
+    private String atte; // 근태(출장 = b , 휴가 = v, 출근 = c) // default = c
 
     @Column(name = "msg_stat", nullable = false, length = 1)
-    private String msgStat; // 메시지 상태 ( 근무 중 = c, 회의 중 = m, 업무 집중 = d, 자리 비움 = x) // default = c
+    private String msgStat ; // 메시지 상태 ( 근무 중 = c, 회의 중 = m, 업무 집중 = d, 자리 비움 = x, 출근 안함 = h) // default = h
 
     // Self Reference (대직자 - emp_id 참조 유지)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "delegate", referencedColumnName = "emp_id")
     private Employee delegate;
+
+    @PrePersist
+    public void prePersist() {
+        if (msgStat == null) msgStat = "h";
+    } // 사원 상태 기본 출근 전으로 세팅
 }

--- a/src/main/resources/templates/company/common/signup.html
+++ b/src/main/resources/templates/company/common/signup.html
@@ -159,7 +159,6 @@
             font-weight:700;
         }
 
-        /* ✅ 비밀번호 확인 메시지 스타일 */
         #pwdMatchMsg {
             font-size: 12px;
             margin: 6px 0 0 10px;
@@ -196,6 +195,10 @@
             text-align:left;
             font-size:13px;
             color:#666;
+        }
+        .note-success{
+            color: var(--success);
+            font-weight: 800;
         }
     </style>
 </head>
@@ -317,7 +320,37 @@
 
     let brnVerified = false;
 
-    // ✅ 실시간 비밀번호 일치 확인 함수
+    function showError(msg) {
+        serverError.textContent = msg || '요청 처리 중 오류가 발생했습니다.';
+        serverError.style.display = 'block';
+    }
+
+    async function readJsonSafely(res) {
+        const ct = res.headers.get('content-type') || '';
+        if (ct.includes('application/json')) return await res.json();
+        const text = await res.text();
+        try { return JSON.parse(text); } catch { return { message: text }; }
+    }
+
+    function normalizeComId() {
+        return (document.getElementById('comId').value || '').trim().toUpperCase();
+    }
+
+    function normalizeBrn() {
+        return (document.getElementById('brn').value || '').replaceAll('-', '').trim();
+    }
+
+    function updateSignupButtonState() {
+        signupBtn.disabled = !brnVerified;
+
+        if (!brnVerified) {
+            brnNote.classList.remove('note-success');
+            brnNote.textContent = '* 사업자등록번호 인증을 완료해야 회원가입 버튼이 활성화됩니다.';
+        }
+    }
+    updateSignupButtonState();
+
+    // ✅ 실시간 비밀번호 일치 확인
     function checkPasswordMatch() {
         const pwd = pwdInput.value;
         const confirm = pwdConfirmInput.value;
@@ -336,30 +369,96 @@
             pwdMatchMsg.className = 'match-error';
         }
     }
-
-    // 입력할 때마다 함수 호출
     pwdInput.addEventListener('input', checkPasswordMatch);
     pwdConfirmInput.addEventListener('input', checkPasswordMatch);
 
-    function updateSignupButtonState() {
-        signupBtn.disabled = !brnVerified;
-        brnNote.style.display = brnVerified ? 'none' : 'block';
-    }
-    updateSignupButtonState();
+    // ✅ BRN 값이 바뀌면 인증 다시 해야 함
+    document.getElementById('brn').addEventListener('input', () => {
+        if (!brnVerified) return;
+        brnVerified = false;
+        brnVerifyBtn.disabled = false;
+        brnVerifyBtn.textContent = '인증하기';
+        updateSignupButtonState();
+    });
 
+    // ✅ 사업자번호 인증: /auth/companies/verify-brn 호출
     brnVerifyBtn.addEventListener('click', async () => {
         serverError.style.display = 'none';
         serverError.textContent = '';
 
-        alert('사업자 인증은 추후 구현 예정입니다. (현재는 인증 완료 처리)');
-        brnVerified = true;
+        const brn = normalizeBrn();
+        if (!brn) {
+            showError('사업자등록번호를 입력해주세요.');
+            document.getElementById('brn').focus();
+            return;
+        }
 
-        brnVerifyBtn.textContent = '인증완료';
-        brnVerifyBtn.disabled = true;
+        // 필요하면 숫자만 검사도 가능
+        // if (!/^\d+$/.test(brn)) { showError('사업자등록번호는 숫자만 입력해주세요.'); return; }
 
-        updateSignupButtonState();
+        try {
+            brnVerifyBtn.disabled = true;
+            brnVerifyBtn.textContent = '인증중...';
+
+            // 백엔드가 @RequestParam으로 받기 편하게 FormData 사용
+            const fd = new FormData();
+            fd.set('brn', brn);
+
+            // 백엔드가 comId까지 필요하면 같이 전송 (선택)
+            const comId = normalizeComId();
+            if (comId) fd.set('comId', comId);
+
+            const res = await fetch('/auth/companies/verify-brn', {
+                method: 'POST',
+                body: fd
+            });
+
+            const result = await readJsonSafely(res);
+
+            if (!res.ok) {
+                brnVerified = false;
+                showError(result?.message || '사업자 인증에 실패했습니다.');
+                brnVerifyBtn.disabled = false;
+                brnVerifyBtn.textContent = '인증하기';
+                updateSignupButtonState();
+                return;
+            }
+
+            // 백엔드 응답 형식 예시:
+            // { "verified": true, "message": "인증 성공" }
+            // 또는 true/false만 내려줄 수도 있어서 둘 다 처리
+            const verified = (typeof result === 'boolean')
+                ? result
+                : (result?.verified !== undefined ? !!result.verified : true);
+
+            if (!verified) {
+                brnVerified = false;
+                showError(result?.message || '사업자 인증에 실패했습니다.');
+                brnVerifyBtn.disabled = false;
+                brnVerifyBtn.textContent = '인증하기';
+                updateSignupButtonState();
+                return;
+            }
+
+            brnVerified = true;
+            brnVerifyBtn.textContent = '인증완료';
+            brnVerifyBtn.disabled = true;
+
+            brnNote.classList.add('note-success');
+            brnNote.textContent = result?.message || '✓ 사업자등록번호 인증이 완료되었습니다.';
+
+            updateSignupButtonState();
+        } catch (err) {
+            console.error(err);
+            brnVerified = false;
+            showError('사업자 인증 요청 중 오류가 발생했습니다.');
+            brnVerifyBtn.disabled = false;
+            brnVerifyBtn.textContent = '인증하기';
+            updateSignupButtonState();
+        }
     });
 
+    // 로고 미리보기
     logoInput.addEventListener('change', () => {
         const file = logoInput.files?.[0];
         if (!file) {
@@ -372,31 +471,28 @@
         logoPreview.style.display = 'flex';
     });
 
+    // ✅ 실제 회원가입 제출: /auth/companies/signup
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
         serverError.style.display = 'none';
         serverError.textContent = '';
 
         if (!brnVerified) {
-            serverError.textContent = '사업자 등록번호 인증을 먼저 진행해주세요.';
-            serverError.style.display = 'block';
+            showError('사업자 등록번호 인증을 먼저 진행해주세요.');
             return;
         }
 
-        // 최종 제출 전 비밀번호 확인
         if (pwdInput.value !== pwdConfirmInput.value) {
-            serverError.textContent = '비밀번호가 일치하지 않습니다.';
-            serverError.style.display = 'block';
+            showError('비밀번호가 일치하지 않습니다.');
             pwdConfirmInput.focus();
             return;
         }
 
         const fd = new FormData(form);
-        const comId = (document.getElementById('comId').value || '').trim().toUpperCase();
-        fd.set('comId', comId);
 
-        const brn = (document.getElementById('brn').value || '').replaceAll('-', '').trim();
-        fd.set('brn', brn);
+        // 정규화
+        fd.set('comId', normalizeComId());
+        fd.set('brn', normalizeBrn());
 
         try {
             signupBtn.disabled = true;
@@ -406,20 +502,18 @@
                 body: fd
             });
 
-            const result = await res.json();
+            const result = await readJsonSafely(res);
 
             if (res.ok) {
                 alert(result?.message || '회원가입 성공!');
                 window.location.href = '/auth/companies/login';
             } else {
-                serverError.textContent = result?.message || '회원가입에 실패했습니다.';
-                serverError.style.display = 'block';
+                showError(result?.message || '회원가입에 실패했습니다.');
                 signupBtn.disabled = false;
             }
         } catch (err) {
             console.error(err);
-            serverError.textContent = '회원가입 요청 중 오류가 발생했습니다.';
-            serverError.style.display = 'block';
+            showError('회원가입 요청 중 오류가 발생했습니다.');
             signupBtn.disabled = false;
         }
     });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #58

## 📝 작업 내용
- 사업자등록번호 인증 외부 api 연결(/validate, /status 중 /status 선택 추후 변경 가능)
      /validate : 사업자등록번호, 대표자 이름, 개업일시를 받아서 현재 운영 여부까지 판단
      /status : 사업자등록번호만 받아 운영중이든 폐업이든 있기만 하면 확인
      운영 중인 사업자등록번호를 얻을 수 없다고 판단해 /status 사용
- 사업자등록번호 인증 로직 작성
- 회원가입 페이지 수정

## 체크리스트
- [x]  사업자등록번호 인증 외부 api 연결
- [x] 사업자등록번호 인증 로직 작성
- [x] 회원가입 페이지 수정

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
