### PR TITLE
fix : 채팅 관련 버그 수정 및 프론트 디자인 수정

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatRoomMember.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatRoomMember.java
@@ -43,7 +43,7 @@ public class ChatRoomMember {
     private LocalDateTime lastReadAt;
 
     @Column(name = "unread_count", columnDefinition = "int default 0 ")
-    private int unreadCount = 0; // 자바 객체 생성 시에도 0으로 초기화
+    private int unreadCount = 0;
 
     @Column(name="is_active", columnDefinition = "boolean default false",nullable=false)
     private boolean isActive;
@@ -78,6 +78,8 @@ public class ChatRoomMember {
         this.unreadCount = 0;
         this.lastReadAt = null;
     }
+
+
 
 
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/dto/ResChatRoomListDto.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/dto/ResChatRoomListDto.java
@@ -25,6 +25,8 @@ public class ResChatRoomListDto {
     private String lastMessage;
     private LocalDateTime lastMessageAt;
     private int unreadCount;
+    private RoomType roomType;
+    private int memberCount;
 
     public static ResChatRoomListDto from(ChatRoom room, String myEmpId) {
 
@@ -34,7 +36,12 @@ public class ResChatRoomListDto {
                 .map(ChatRoomMember::getUnreadCount)
                 .orElse(0);
 
-        List<String> otherNames = room.getMembers().stream()
+
+        List<ChatRoomMember> activeMembers = room.getMembers().stream()
+                .filter(ChatRoomMember::isActive) // ✅ 활성 상태인 멤버만 필터링
+                .toList();
+
+        List<String> otherNames = activeMembers.stream()
                 .map(ChatRoomMember::getEmployee)
                 .filter(emp -> !emp.getEmpId().equals(myEmpId))
                 .map(Employee::getEmpName)
@@ -42,10 +49,8 @@ public class ResChatRoomListDto {
 
         String displayName;
         if (room.getRoomType() == RoomType.ONE) {
-            // 1:1 채팅방: 나를 제외한 유일한 상대방의 이름을 사용
             displayName = otherNames.isEmpty() ? "알 수 없는 사용자" : otherNames.get(0);
         } else {
-            // 그룹 채팅방: 저장된 방 이름이 있으면 사용, 없으면 참여자 이름을 합쳐서 생성
             if (room.getRoomName() != null && !room.getRoomName().isBlank()) {
                 displayName = room.getRoomName();
             } else {
@@ -58,7 +63,9 @@ public class ResChatRoomListDto {
                 displayName,
                 room.getLastMessage(),
                 room.getLastMessageAt(),
-                unreadCount
+                unreadCount,
+                room.getRoomType(),
+                activeMembers.size()
         );
     }
 

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/dto/ResChatRoomUpdateDto.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/dto/ResChatRoomUpdateDto.java
@@ -1,5 +1,6 @@
 package com.multi.mlpenterpriseapprovalsystem.chat.dto;
 
+import com.multi.mlpenterpriseapprovalsystem.chat.domain.RoomType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,4 +22,7 @@ public class ResChatRoomUpdateDto {
     private int unreadCount;
     private String roomName;
     private boolean removed;
+    private RoomType roomType;
+    private int memberCount;
+
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/redis/ChatRedisPublisher.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/redis/ChatRedisPublisher.java
@@ -67,9 +67,6 @@ public class ChatRedisPublisher {
         }
     }
 
-    public void publishSystem(Long roomNo, ResChatMessageDto dto) {
-        publish(roomNo, dto);
-    }
 
     public void publishSystem(Long roomNo, String content) {
         try {

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/repository/ChatRoomMemberRepository.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/repository/ChatRoomMemberRepository.java
@@ -24,6 +24,8 @@ public interface ChatRoomMemberRepository extends JpaRepository<ChatRoomMember, 
 
     boolean existsByChatRoom_RoomNoAndEmployee_EmpIdAndIsActiveTrue(Long roomNo, String empId);
 
+    long countByChatRoom_RoomNoAndIsActiveTrue(Long roomNo);
+
     Optional<ChatRoomMember> findByChatRoom_RoomNoAndEmployee_EmpId(Long roomNo, String empId);
 
     Optional<ChatRoomMember> findByChatRoom_RoomNoAndEmployee_EmpIdAndIsActiveTrue(Long roomNo, String empId);

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/service/ChatMessageService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/service/ChatMessageService.java
@@ -46,6 +46,7 @@ public class ChatMessageService {
     /**
      * 메시지 전송
      */
+    @Transactional
     public ResChatMessageDto sendMessage(ReqChatMessageSendDto request, String empId) {
 
         ChatRoom chatRoom = chatRoomRepository.findById(request.getRoomNo())
@@ -57,9 +58,11 @@ public class ChatMessageService {
 
         LocalDateTime now = LocalDateTime.now();
 
+        // 1. 발신자 활성화 처리 (1:1 복귀 로직)
         if (!senderMember.isActive()) {
             if (chatRoom.getRoomType() == RoomType.ONE) {
                 chatRoomMemberRepository.reactivateMe(request.getRoomNo(), empId, now);
+                senderMember.reactivateNow(now);
             } else {
                 throw new CustomException(ErrorCode.CHAT_ACCESS_DENIED);
             }
@@ -79,30 +82,39 @@ public class ChatMessageService {
 
         ChatMessage savedMessage = chatMessageRepository.save(message);
 
-        // 1:1이면 상대가 나가(active=false) 있어도 메시지 한 번 오면 다시 뜨게(자동 복귀)
-        //  joinedAt을 now로 바꿔서 "복귀 이후 메시지만" 보이게 한다.
+        // 2. 1:1인 경우 상대방도 자동으로 활성화(복귀) 처리
         if (chatRoom.getRoomType() == RoomType.ONE) {
             chatRoomMemberRepository.reactivateOthersForOneToOne(request.getRoomNo(), empId, now);
+            // ✅ 상대방 메모리 객체 상태도 활성화로 업데이트하여 카운트에 반영
+            chatRoom.getMembers().forEach(m -> {
+                if (!m.getEmployee().getEmpId().equals(empId)) m.reactivateNow(now);
+            });
         }
+
+        // 3. 현재 활성 상태인 멤버 수 계산
+        int activeMemberCount = (int) chatRoom.getMembers().stream()
+                .filter(ChatRoomMember::isActive)
+                .count();
 
         ResChatMessageDto responseDto = ResChatMessageDto.from(savedMessage);
         redisPublisher.publish(request.getRoomNo(), responseDto);
 
         chatRoom.updateLastMessage(savedMessage.getContent(), savedMessage.getCreatedAt());
 
+        // 안읽은 메시지 처리
         String viewingKey = "chat:room:" + request.getRoomNo() + ":viewing";
         Set<String> viewingEmpIds = redisTemplate.opsForSet().members(viewingKey);
         if (viewingEmpIds == null) viewingEmpIds = Set.of();
 
         chatRoomMemberRepository.increaseUnreadExceptViewers(request.getRoomNo(), empId, viewingEmpIds);
 
-        String preview = chatRoom.getLastMessage();                 // ← trim 적용된 값
-        String previewAtIso = chatRoom.getLastMessageAt().toString(); // ← updateLastMessage에서 세팅된 값
+        String preview = chatRoom.getLastMessage();
+        String previewAtIso = chatRoom.getLastMessageAt().toString();
 
+        // 모든 멤버 아이디 가져오기 (실시간 알림 대상)
         List<String> memberEmpIds = chatRoomMemberRepository.findEmpIdsByRoomNo(request.getRoomNo());
 
         for (String targetEmpId : memberEmpIds) {
-
             long unreadLong;
             if (targetEmpId.equals(empId)) {
                 unreadLong = 0L;
@@ -113,28 +125,33 @@ public class ChatMessageService {
 
             int unread = unreadLong > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) unreadLong;
 
-            // ✅ [수정 포인트] 각 수신자(targetEmpId)의 시점에서 보여줄 방 이름 결정
+            // 수신자 시점의 방 이름 결정
             String finalRoomName;
             if (chatRoom.getRoomType() == RoomType.ONE) {
-                // 1:1 채팅방: 수신자(targetEmpId)가 아닌 '상대방'의 이름을 찾음
                 finalRoomName = chatRoom.getMembers().stream()
                         .filter(m -> !m.getEmployee().getEmpId().equals(targetEmpId))
                         .map(m -> m.getEmployee().getEmpName())
                         .findFirst()
                         .orElse("알 수 없는 사용자");
             } else {
-                // 그룹 채팅방: 저장된 방 이름 사용 (없으면 기본값)
                 finalRoomName = chatRoom.getRoomName() != null ? chatRoom.getRoomName() : "그룹 채팅";
             }
+
+
 
             ResChatRoomUpdateDto updateDto = new ResChatRoomUpdateDto(
                     request.getRoomNo(),
                     preview,
                     previewAtIso,
                     unread,
-                    finalRoomName // ✅ 계산된 실시간 방 이름을 전달
-                    ,false
+                    finalRoomName,
+                    false,
+                    chatRoom.getRoomType(),
+                    activeMemberCount
             );
+
+            System.out.println("########### activeMemberCount "+ activeMemberCount);
+
             if (message.getType() == MessageType.SYSTEM) {
                 continue;
             }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/service/ChatRoomService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/service/ChatRoomService.java
@@ -230,6 +230,10 @@ public class ChatRoomService {
         String content = (latestMsg != null) ? latestMsg.getContent() : null;
         String createdAt = (latestMsg != null) ? latestMsg.getCreatedAt().toString() : null;
 
+        int activeMemberCount = (int) room.getMembers().stream()
+                .filter(ChatRoomMember::isActive)
+                .count();
+
         // 3. 최신 데이터(상대방 이름 포함)로 목록 업데이트 알림 전송
         ResChatRoomUpdateDto updateDto = new ResChatRoomUpdateDto(
                 roomNo,
@@ -238,6 +242,8 @@ public class ChatRoomService {
                 0, // 읽음 처리되었으므로 0
                 roomName // ✅ 이제 내가 아닌 상대방의 이름이 전달됨
                 ,false
+                ,room.getRoomType()
+                ,activeMemberCount
         );
 
         redisPublisher.publishRoomUpdate(empId, updateDto);
@@ -254,7 +260,7 @@ public class ChatRoomService {
                 .senderEmpId("SYSTEM")
                 .senderName("SYSTEM")
                 .content(content)
-                .type(MessageType.SYSTEM)   // ← ChatMessage 엔티티 필드명이 type가 아니면 너 필드명에 맞게만 바꿔
+                .type(MessageType.SYSTEM)
                 .createdAt(LocalDateTime.now())
                 .build();
         chatMessageRepository.save(systemMessage);
@@ -287,7 +293,7 @@ public class ChatRoomService {
         if (RoomType.GROUP.equals(member.getChatRoom().getRoomType())) {
             saveAndPublishSystemMessage(roomNo, leaver.getEmpName() + "님이 나갔습니다.");
         }
-        ResChatRoomUpdateDto dto = new ResChatRoomUpdateDto(roomNo, null, null, 0, null,true);
+        ResChatRoomUpdateDto dto = new ResChatRoomUpdateDto(roomNo, null, null, 0, null,true,RoomType.ONE,0);
         redisPublisher.publishRoomUpdate(empId, dto);
 
         log.info("[LEAVE] roomNo={}, empId={}, type={}", roomNo, empId, room.getRoomType());

--- a/src/main/resources/templates/chat/chat-main.html
+++ b/src/main/resources/templates/chat/chat-main.html
@@ -348,10 +348,24 @@
             ? `<span class="badge">${r.unreadCount > 999 ? "999+" : r.unreadCount}</span>` : "";
         const timeHtml = r.lastMessageAt ? `<div class="last-msg-time">${formatTime(r.lastMessageAt)}</div>` : "";
 
+        const memberCountHtml = (r.roomType === 'GROUP' && r.memberCount > 0)
+            ? `<span style="color: #999; font-size: 13px; font-weight: normal; margin-left: 6px; display: inline-flex; align-items: center; gap: 3px;">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-top: -1px;">
+                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+                <circle cx="9" cy="7" r="4"></circle>
+                <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+                <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+            </svg>
+            ${r.memberCount}
+           </span>`
+            : "";
+
         div.innerHTML = `
         <div class="row-content">
             <div class="room-info">
-                <div class="title">${escapeHtml(r.roomName)}</div>
+                <div class="title" style="display: flex; align-items: center;">
+                    ${escapeHtml(r.roomName)}${memberCountHtml}
+                </div>
                 <div class="sub">
                     <span class="last-msg-text">
                         ${escapeHtml(r.lastMessage || "대화 내용이 없습니다.")}

--- a/src/main/resources/templates/chat/chat-room.html
+++ b/src/main/resources/templates/chat/chat-room.html
@@ -79,21 +79,62 @@
         .time-info { font-size: 10px; color: #aaa; margin-top: 4px; }
 
         /* 하단 바 */
-        .bottom { padding: 15px 20px; background: white; border-top: 1px solid var(--border-color); display: flex; gap: 10px; }
+        /* .bottom 스타일 수정 및 추가 */
+        /* chat-room.html의 <style> 부분 수정 */
+        .bottom {
+            padding: 10px 15px 5px; /* 아래 간격 조정 */
+            background: white;
+            border-top: 1px solid var(--border-color);
+        }
+
+        .bottom textarea {
+            width: 100%;
+            padding: 10px 12px;
+            border: 1px solid #ddd;
+            border-radius: 8px;
+            outline: none;
+            font-size: 14px;
+            resize: none;
+            height: 40px;
+            max-height: 100px;
+
+            /* ✅ 핵심: 초기 스크롤바 숨김 */
+            overflow: hidden;
+
+            line-height: 1.4;
+            font-family: inherit;
+            box-sizing: border-box;
+        }
+        .bottom textarea:focus { border-color: var(--primary-color); }
         .bottom input { flex: 1; padding: 12px 15px; border: 1px solid #ddd; border-radius: 8px; outline: none; font-size: 14px; transition: border-color 0.2s; }
         .bottom input:focus { border-color: var(--primary-color); }
         .bottom button { padding: 0 20px; background: var(--primary-color); color: white; border: none; border-radius: 8px; font-weight: 700; cursor: pointer; }
         .bottom button:disabled { background: #ccc; cursor: not-allowed; }
 
         /* ✅ 추가된 바이트 바 스타일 */
+        /* ✅ 바이트 바와 버튼 레이아웃 수정 */
         .bytebar {
-            padding: 0 20px 12px;
-            font-size: 12px;
-            color: #777;
-            display:flex;
-            justify-content:space-between;
-            align-items:center;
+            padding: 0 15px 12px;
             background: white;
+            display: flex;
+            justify-content: space-between; /* 양 끝으로 배치 */
+            align-items: center;
+        }
+
+        .bytebar button {
+            padding: 8px 20px;
+            background: var(--primary-color);
+            color: white;
+            border: none;
+            border-radius: 8px;
+            font-weight: 700;
+            cursor: pointer;
+            transition: opacity 0.2s;
+        }
+
+        .bytebar button:disabled {
+            background: #ccc;
+            cursor: not-allowed;
         }
         .bytebar .warn { color:#ff3b30; font-weight:700; }
 
@@ -161,13 +202,15 @@
     <div class="msgs" id="messages"></div>
 
     <div class="bottom">
-        <input id="messageInput" placeholder="메시지를 입력하세요..." onkeydown="if(event.keyCode==13){sendMessage()}" autocomplete="off" />
-        <button id="sendBtn" onclick="sendMessage()">전송</button>
+        <textarea id="messageInput" placeholder="메시지를 입력하세요..." rows="1" autocomplete="off"></textarea>
     </div>
 
     <div class="bytebar">
-        <span id="byteInfo">0 / 61440 bytes</span>
-        <span id="byteWarn" style="display:none;" class="warn">용량 초과</span>
+        <div id="byteGroup">
+            <span id="byteInfo">0 / 61440 bytes</span>
+            <span id="byteWarn" style="display:none;" class="warn">용량 초과</span>
+        </div>
+        <button id="sendBtn" onclick="sendMessage()">전송</button>
     </div>
 </div>
 
@@ -449,12 +492,12 @@
         box.scrollTop = box.scrollHeight;
     }
 
+    // sendMessage 함수 내 input.value 초기화 후 높이 초기화 로직 추가
     function sendMessage() {
         const input = document.getElementById("messageInput");
         const content = input.value.trim();
         if (!content || !stompClient?.connected) return;
 
-        // ✅ 전송 전 바이트 제한 최종 체크
         if (utf8Bytes(content) > MAX_BYTES) {
             alert("메시지 용량이 너무 큽니다.");
             return;
@@ -463,7 +506,10 @@
         stompClient.send("/pub/chat/message", { Authorization: 'Bearer ' + getAccessToken() },
             JSON.stringify({ roomNo: roomNo, content: content })
         );
+
         input.value = "";
+        input.style.height = '40px'; // ✅ 전송 후 다시 한 줄 높이로 초기화
+        input.style.overflowY = 'hidden'; // ✅ 전송 후 스크롤바 다시 숨김
         updateByteInfo();
     }
 
@@ -474,10 +520,38 @@
     });
 
     window.addEventListener("load", () => {
+        const messageInput = document.getElementById("messageInput");
+
+        messageInput.addEventListener("input", function() {
+            // 높이 초기화 후 재계산
+            this.style.height = '40px';
+            const newHeight = this.scrollHeight;
+            this.style.height = newHeight + 'px';
+
+            // ✅ 최대 높이(100px)를 넘으면 스크롤바 표시, 아니면 숨김
+            if (newHeight >= 100) {
+                this.style.overflowY = 'auto';
+            } else {
+                this.style.overflowY = 'hidden';
+            }
+
+            updateByteInfo();
+        });
+
+// 엔터키 전송 로직 수정
+        messageInput.addEventListener("keydown", function(e) {
+            // ✅ [핵심] 한글 조합 중(IME)일 때는 엔터 처리를 무시함
+            if (e.isComposing) return;
+
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                sendMessage();
+            }
+        });
+
         loadRoomInfo();
         connectWs();
-        updateByteInfo(); // 바이트 카운터 초기화
-        document.getElementById("messageInput").addEventListener("input", updateByteInfo);
+        updateByteInfo();
     });
 </script>
 </body>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #153

## 📝 작업 내용
- resDto에 roomtype과 MemberCount를 같이 넘겨서 publish할때 roomtype, membercount를 기존 것과 같이 실시간으로 넘김
- 채팅방 목록 조회 화면에서 단톡방이면 해당 채팅방 이름 옆에 참여자 수 보이게
- 채팅방 내부 화면 : 채팅 박스 크기 크게, 채팅 길어지면 스크롤로 밑으로 보이게 구현

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
