### PR TITLE
refactor : 채팅방 이름 제한 50자로 수정 및 프론트 버그 수정

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatRoom.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/domain/ChatRoom.java
@@ -27,6 +27,7 @@ public class ChatRoom extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long roomNo;
+    @Column(name = "room_name",columnDefinition = "varchar(50)")
     private String roomName;
     @Enumerated(EnumType.STRING)
     private RoomType roomType;

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/service/ChatRoomService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/service/ChatRoomService.java
@@ -63,7 +63,6 @@ public class ChatRoomService {
             throw new CustomException(ErrorCode.INVALID_MEMBER_COUNT);
         }
 
-        // ✅ 회사 comId 검증
         for (String targetEmpId : targets) {
             Employee target = employeeRepository.findByEmpId(targetEmpId)
                     .orElseThrow(() -> new CustomException(ErrorCode.EMPLOYEE_NOT_FOUND));
@@ -122,24 +121,22 @@ public class ChatRoomService {
                 empNames.add(me.getEmpName());
 
                 for (String id : request.getMemberIds()) {
+                    if (empNames.size() >= 5) break;
                     Employee emp = employeeRepository.findByEmpId(id)
                             .orElseThrow(() -> new CustomException(ErrorCode.EMPLOYEE_NOT_FOUND));
                     empNames.add(emp.getEmpName());
                 }
 
                 roomName = String.join(", ", empNames);
-                if (roomName.length() > 255) {
-                    roomName = roomName.substring(0, 250) + "...";
+                if (roomName.length() > 45) {
+                    roomName = roomName.substring(0, 45) + "...";
                 }
             } else {
                 roomName = request.getRoomName();
-                if (roomName.length() > 255) {
+                if (roomName.length() > 50) {
                     throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
                 }
             }
-        }
-        if (roomName != null && roomName.length() > 255) {
-            throw new CustomException(ErrorCode.INVALID_INPUT_VALUE);
         }
 
         ChatRoom chatRoom = chatRoomRepository.save(ChatRoom.create(roomName, roomType));

--- a/src/main/resources/templates/chat/chat-create.html
+++ b/src/main/resources/templates/chat/chat-create.html
@@ -66,7 +66,7 @@
     <div class="footer">
         <div class="input-group">
             <input id="roomName" placeholder="채팅방 이름을 입력하세요 (미입력 시 멤버 이름으로 설정)" />
-            <span id="nameCount" class="count-info">0 / 250 자</span>
+            <span id="nameCount" class="count-info">0 / 50 자</span>
         </div>
         <button id="createBtn" onclick="createRoom()">채팅방 생성</button>
     </div>
@@ -155,8 +155,7 @@
         loading = false;
     }
 
-    // ✅ [추가] 채팅방 이름 250자 제한 로직
-    const MAX_CHARS = 250;
+    const MAX_CHARS = 50;
     function updateNameCount() {
         const input = document.getElementById("roomName");
         const countInfo = document.getElementById("nameCount");

--- a/src/main/resources/templates/chat/chat-main.html
+++ b/src/main/resources/templates/chat/chat-main.html
@@ -108,10 +108,9 @@
         .row .title {
             font-weight: 700;
             font-size: 15px;
-            overflow: hidden;
-            text-overflow: ellipsis;
-            white-space: nowrap;
             margin-bottom: 4px;
+            /* ✅ 기존의 overflow, text-overflow, white-space는 제거하거나 무시됩니다. */
+            min-width: 0; /* 중요: flex 자식이 넘칠 때 말줄임표가 작동하게 함 */
         }
 
         .row .sub {
@@ -349,35 +348,38 @@
         const timeHtml = r.lastMessageAt ? `<div class="last-msg-time">${formatTime(r.lastMessageAt)}</div>` : "";
 
         const memberCountHtml = (r.roomType === 'GROUP' && r.memberCount > 0)
-            ? `<span style="color: #999; font-size: 13px; font-weight: normal; margin-left: 6px; display: inline-flex; align-items: center; gap: 3px;">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-top: -1px;">
-                <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
-                <circle cx="9" cy="7" r="4"></circle>
-                <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
-                <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
-            </svg>
-            ${r.memberCount}
-           </span>`
+            ? `<span style="color: #999; font-size: 13px; font-weight: normal; margin-left: 6px; display: inline-flex; align-items: center; gap: 3px; flex-shrink: 0;">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="vertical-align: middle; margin-top: -1px;">
+            <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"></path>
+            <circle cx="9" cy="7" r="4"></circle>
+            <path d="M23 21v-2a4 4 0 0 0-3-3.87"></path>
+            <path d="M16 3.13a4 4 0 0 1 0 7.75"></path>
+        </svg>
+        ${r.memberCount}
+       </span>`
             : "";
 
         div.innerHTML = `
-        <div class="row-content">
-            <div class="room-info">
-                <div class="title" style="display: flex; align-items: center;">
-                    ${escapeHtml(r.roomName)}${memberCountHtml}
-                </div>
-                <div class="sub">
-                    <span class="last-msg-text">
-                        ${escapeHtml(r.lastMessage || "대화 내용이 없습니다.")}
-                    </span>
-                </div>
+    <div class="row-content">
+        <div class="room-info">
+            <div class="title" style="display: flex; align-items: center;">
+                <span style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                    ${escapeHtml(r.roomName)}
+                </span>
+                ${memberCountHtml}
             </div>
-            <div class="room-meta">
-                ${timeHtml}
-                ${badgeHtml}
+            <div class="sub">
+                <span class="last-msg-text">
+                    ${escapeHtml(r.lastMessage || "대화 내용이 없습니다.")}
+                </span>
             </div>
         </div>
-    `;
+        <div class="room-meta">
+            ${timeHtml}
+            ${badgeHtml}
+        </div>
+    </div>
+`;
     }
 
     function onRoomSearchInput() { clearTimeout(roomKwTimer); roomKwTimer = setTimeout(initRooms, 300); }

--- a/src/main/resources/templates/chat/chat-room.html
+++ b/src/main/resources/templates/chat/chat-room.html
@@ -8,8 +8,7 @@
         body { font-family: 'Pretendard', sans-serif; margin: 0; background-color: var(--bg-color); color: #333; }
         .wrap { height: 100vh; display: flex; flex-direction: column; position: relative; }
 
-        /* 상단 바 */
-        /* 상단 바 레이아웃 유지 */
+
         .top {
             padding: 14px 18px;
             border-bottom: 1px solid var(--border-color);
@@ -19,18 +18,62 @@
             background: white;
             box-shadow: 0 2px 4px rgba(0,0,0,0.02);
             z-index: 10;
-            gap: 10px; /* 제목과 버튼 사이 최소 간격 */
+            gap: 10px;
         }
-        /* ✅ 채팅방 이름 말줄임 처리 */
         .title {
+            flex: 1;
+            min-width: 0;
+            max-width: 200px;
+            position: relative;
+            cursor: pointer;
+            overflow: visible !important;
+        }
+
+        /* ✅ 실제 제목 텍스트 전용 스타일 (말줄임 유지) */
+        .title-text {
+            display: block;
             font-weight: 800;
             font-size: 16px;
-            white-space: nowrap;      /* 줄바꿈 금지 */
-            overflow: hidden;         /* 넘치는 부분 숨김 */
-            text-overflow: ellipsis;  /* ... 표시 */
-            flex: 1;                  /* 남는 공간을 차지하게 함 */
-            min-width: 0;             /* flex 아이템이 넘칠 때 줄어들 수 있게 함 (중요) */
-            max-width: 200px;         /* 16px 기준 약 12~13자 정도의 너비 제한 */
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            width: 100%;
+        }
+
+        /* chat-room.html <style> 부분 수정 */
+
+        /* 1. 툴팁의 기본 상태 (숨김) */
+        .title::after {
+            content: attr(data-title);
+            position: absolute;
+            top: 100%;
+            left: 0;
+            margin-top: 8px;
+            background: rgba(0, 0, 0, 0.85);
+            color: #fff;
+            padding: 10px 14px;
+            border-radius: 6px;
+            font-size: 13px;
+            font-weight: 400;
+            z-index: 9999;
+            pointer-events: none;
+            box-shadow: 0 4px 12px rgba(0,0,0,0.2);
+            white-space: normal;
+            width: max-content;
+            max-width: 250px;
+            word-break: break-all;
+            line-height: 1.5;
+
+            opacity: 0;
+            visibility: hidden;
+            transition: opacity 0.3s, visibility 0.3s;
+        }
+
+        .title:hover::after {
+            opacity: 1;
+            visibility: visible;
+
+            transition-delay: 0.4s;
         }
         /* 버튼 영역이 찌그러지지 않게 고정 */
         .actions {
@@ -275,13 +318,20 @@
 
             let displayName = room.roomName;
 
-            // ✅ 1:1 채팅방이거나 방 이름이 없는 경우, 참여자 목록에서 상대방 이름을 찾음
             if (room.roomType === 'ONE' || !displayName) {
                 const opponent = (room.members || []).find(m => m.empId !== MY_EMP_ID);
                 displayName = opponent ? opponent.empName : (displayName || "대화 상대 없음");
             }
 
-            document.getElementById("roomTitle").innerText = displayName;
+            const titleEl = document.getElementById("roomTitle");
+
+            // ✅ [수정] 텍스트 전용 span(title-text)을 만들어서 넣어줌
+            // 이렇게 해야 제목은 '...'으로 유지되면서 툴팁만 아래에 뜹니다.
+            titleEl.innerHTML = `<span class="title-text">${escapeHtml(displayName)}</span>`;
+
+            // ✅ 툴팁에 표시될 전체 이름 설정
+            titleEl.setAttribute('data-title', displayName);
+            titleEl.removeAttribute('title');
         } catch (err) {
             console.error("방 정보 로드 실패:", err);
             document.getElementById("roomTitle").innerText = "채팅방";


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #156 

## 📝 작업 내용
- 채팅방 이름 제한 50자로 변경 (백 로직 수정 및 프론트 수정)
- 채팅방 목록 페이지에서 채팅방 이름이 50자 이상이면 인원 수 안 보이는 버그 수정
- 채팅방 내부에서 채팅방 이름에 마우스 올릴시 전체 이름 뜨게 구현

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
