### PR TITLE
refactor: accesstoken 전송 방식 httpOnly Cookie로 변경

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/auth/controller/AuthController.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/auth/controller/AuthController.java
@@ -90,19 +90,16 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<ResponseDto<ResTokenDto>> refresh(
-            @RequestHeader("Authorization") String accessToken,
-            HttpServletRequest request
+            HttpServletRequest request,
+            HttpServletResponse response
     ) {
-        ResTokenDto token = tokenService.refreshAccessToken(accessToken, request);
-
+        ResTokenDto token = tokenService.refreshAccessToken(request, response); // (쿠키 기반 버전)
         return ResponseEntity.ok(new ResponseDto<>(HttpStatus.OK, "AccessToken 재발급 성공", token));
     }
 
     @PostMapping("/logout")
-    public ResponseEntity<ResponseDto<Void>> logout(@RequestHeader("Authorization") String accessToken, HttpServletResponse response) {
-
-        tokenService.deleteRefreshToken(accessToken, response);
-
-        return ResponseEntity.status(HttpStatus.OK).body(new ResponseDto<>(HttpStatus.OK, "로그아웃 성공 및 Refresh Token 삭제 완료", null));
+    public ResponseEntity<ResponseDto<Void>> logout(HttpServletRequest request, HttpServletResponse response) {
+        tokenService.logout(request, response);
+        return ResponseEntity.ok(new ResponseDto<>(HttpStatus.OK, "로그아웃 성공", null));
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/jwt/JwtFilter.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/jwt/JwtFilter.java
@@ -7,6 +7,7 @@ import com.multi.mlpenterpriseapprovalsystem.common.exception.TokenException;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -17,6 +18,8 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * JwtFilter
@@ -123,12 +126,14 @@ public class JwtFilter extends OncePerRequestFilter {
     }
 
     private String resolveToken(HttpServletRequest request) {
+        // 1) Authorization 헤더 우선
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
-        //Header에서 Bearer 부분 이하로 붙은 token을 파싱한다.
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
-            return bearerToken.substring(7);
+            return bearerToken.substring(BEARER_PREFIX.length());
         }
-        return null;
+
+        // 2) 없으면 accessToken 쿠키에서 찾기
+        return extractCookie(request, "accessToken").orElse(null);
     }
 
     public String convertObjectToJson(Object object) throws JsonProcessingException {
@@ -137,6 +142,17 @@ public class JwtFilter extends OncePerRequestFilter {
         }
         ObjectMapper mapper = new ObjectMapper();
         return mapper.writeValueAsString(object);
+    }
+
+    private Optional<String> extractCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return Optional.empty();
+
+        return Arrays.stream(cookies)
+                .filter(c -> name.equals(c.getName()))
+                .map(Cookie::getValue)
+                .filter(v -> v != null && !v.isBlank())
+                .findFirst();
     }
 
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/jwt/service/TokenService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/jwt/service/TokenService.java
@@ -72,6 +72,8 @@ public class TokenService {
                 roles
         );
 
+        setAccessCookie(response, accessToken);
+
         return ResTokenDto.builder()
                 .accessToken(accessToken)
                 .expiresInSeconds(tokenProvider.getAccessExpSeconds())
@@ -144,6 +146,17 @@ public class TokenService {
         );
     }
 
+    private void setAccessCookie(HttpServletResponse response, String accessToken) {
+        ResponseCookie cookie = ResponseCookie.from("accessToken", accessToken)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite("Lax")
+                .path("/")
+                .maxAge(tokenProvider.getAccessExpSeconds())
+                .build();
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
     private void setRefreshCookie(HttpServletResponse response, String refreshToken) {
         ResponseCookie cookie = ResponseCookie.from("refreshToken", refreshToken)
                 .httpOnly(true)
@@ -168,25 +181,36 @@ public class TokenService {
      * - accessToken에서 subject 추출해서 해당 유저의 refresh들을 revoke 처리하고 싶으면 여기도 확장 가능
      */
     @Transactional
-    public void deleteRefreshToken(String accessToken, HttpServletResponse response) {
+    public void logout(HttpServletRequest request, HttpServletResponse response) {
 
         try {
-            String token = resolveToken(accessToken);
-            Long subjectId = tokenProvider.getSubjectId(token);
-            TokenSubjectType subjectType = tokenProvider.getSubjectType(token);
+            // 1) refreshToken 쿠키가 없으면 = 이미 로그아웃 상태로 보고 UNAUTHORIZED
+            String refreshToken = extractCookie(request, "refreshToken")
+                    .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
 
+            // 2) RT 서명/만료 검증
+            if (!tokenProvider.validateToken(refreshToken)) {
+                throw new CustomException(ErrorCode.UNAUTHORIZED);
+            }
+
+            // 3) RT claims에서 사용자 식별값 추출
+            Claims rtClaims = tokenProvider.parseClaims(refreshToken);
+
+            Long subjectId = tokenProvider.getSubjectId(rtClaims.getSubject());
+            TokenSubjectType subjectType = tokenProvider.getSubjectType(rtClaims.getSubject());
+
+            // 4) DB에서 유효 RT들 revoke
             var stored = refreshTokenRepository
                     .findAllBySubjectTypeAndSubjectIdAndRevokedFalse(subjectType, subjectId);
 
             if (stored.isEmpty()) {
-                // ✅ 너가 원한대로 UNAUTHORIZED 던짐
                 throw new CustomException(ErrorCode.UNAUTHORIZED);
             }
 
             stored.forEach(RefreshToken::revoke);
 
         } finally {
-            // ✅ 성공/예외(UNAUTHORIZED 포함) 상관없이 쿠키 삭제 헤더는 내려감
+            // ✅ 성공/실패 상관없이 쿠키는 무조건 삭제
             clearAuthCookies(response);
         }
     }
@@ -207,7 +231,7 @@ public class TokenService {
     public void clearAuthCookies(HttpServletResponse response) {
         clearCookie(response, "refreshToken");
         // accessToken을 쿠키로 쓰는 경우만
-        // clearCookie(response, "accessToken");
+        clearCookie(response, "accessToken");
     }
 
     // =========================================================
@@ -218,7 +242,7 @@ public class TokenService {
      * - 만료된 accessToken(Authorization 헤더)에서 subject 정보 추출
      * - 쿠키의 refreshToken 검증 + DB의 최신 revoked=false 토큰과 일치 검증
      */
-    public ResTokenDto refreshAccessToken(String expiredAccessTokenHeader, HttpServletRequest request) {
+    public ResTokenDto refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
 
         String refreshToken = extractCookie(request, "refreshToken")
                 .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
@@ -228,21 +252,15 @@ public class TokenService {
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 2) 만료된 AT에서 Claims 추출 (만료여도 꺼내야 함)
-        String accessJwt = resolveToken(expiredAccessTokenHeader);
+        // 2) RT에서 Claims 추출 (RT는 유효하니 그대로 파싱하면 됨)
+        Claims rtClaims = tokenProvider.parseClaims(refreshToken);
 
-
-        // ⚠️ TokenProvider에 이 메서드가 있어야 함
-        Claims claims = tokenProvider.parseClaims(accessJwt);
-
-        // claims에서 필요한 값들 추출 (TokenProvider에 helper 없으면 claims.get으로 뽑아도 됨)
-        Long subjectId = tokenProvider.getSubjectId(claims.getSubject());
-        TokenSubjectType subjectType = tokenProvider.getSubjectType(claims.getSubject());
-        String comId = tokenProvider.getComId(claims.getSubject());
-        String username = tokenProvider.getUsername(claims.getSubject());
-
-        List<String> roles = tokenProvider.getRoles(claims.getSubject());
-
+        // ✅ 여기서부터: AT 헤더 없이 RT claims로 subject 정보 추출
+        Long subjectId = tokenProvider.getSubjectId(rtClaims.getSubject());
+        TokenSubjectType subjectType = tokenProvider.getSubjectType(rtClaims.getSubject());
+        String comId = tokenProvider.getComId(rtClaims.getSubject());
+        String username = tokenProvider.getUsername(rtClaims.getSubject());
+        List<String> roles = tokenProvider.getRoles(rtClaims.getSubject());
 
         // 3) DB에서 현재 유효 RT(최신 revoked=false) 조회
         RefreshToken dbRT = refreshTokenRepository
@@ -257,18 +275,20 @@ public class TokenService {
 
         // 3-2) DB의 RT와 클라이언트 RT 일치 체크
         if (!dbRT.getToken().equals(refreshToken)) {
-            // 보안 강화: 불일치면 폐기
             dbRT.revoke();
             throw new CustomException(ErrorCode.UNAUTHORIZED);
         }
 
-        // 4) 새 AccessToken 발급
+        // 4) 새 AccessToken 발급 + 쿠키 세팅
         String newAccessToken = tokenProvider.createAccessToken(
                 subjectId, subjectType, comId, username, roles
         );
+        setAccessCookie(response, newAccessToken);
 
+        // ✅ 쿠키만 쓸 거면 accessToken을 바디로 굳이 안 내려도 됨
+        // (호환/디버깅용으로 남겨도 되고, 없애고 싶으면 null로)
         return ResTokenDto.builder()
-                .accessToken(newAccessToken)
+                .accessToken(null) // 또는 newAccessToken (원하면 유지)
                 .expiresInSeconds(tokenProvider.getAccessExpSeconds())
                 .subjectType(subjectType.name())
                 .role(roles.isEmpty() ? null : roles.get(0))

--- a/src/main/resources/templates/company/common/login.html
+++ b/src/main/resources/templates/company/common/login.html
@@ -184,6 +184,12 @@
     const form = document.getElementById('company-login-form');
     const serverError = document.getElementById('serverError');
 
+    async function safeJson(res) {
+        const ct = res.headers.get('content-type') || '';
+        if (!ct.includes('application/json')) return {};
+        try { return await res.json(); } catch { return {}; }
+    }
+
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
         serverError.style.display = 'none';
@@ -196,20 +202,15 @@
             const res = await fetch('/auth/companies/login', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
+                credentials: 'include', // ✅ Set-Cookie(AT/RT)를 저장/전송하기 위해
                 body: JSON.stringify({ email, password })
             });
 
-            const result = await res.json().catch(() => ({}));
+            const result = await safeJson(res);
 
             if (res.ok) {
-                const accessToken = result?.data?.accessToken;
-                if (accessToken) {
-                    localStorage.setItem('accessToken', accessToken);
-                    localStorage.setItem('loginType', 'company'); // ✅ 회사 로그인 표시용
-                    localStorage.setItem('loginId', email);       // ✅ (선택) 표시용
-                }
-
-                // ✅ 메인으로 이동 -> main.html에서 로그인된 UI로 바뀜
+                // ✅ accessToken/refreshToken은 서버가 Set-Cookie로 내려주면
+                // 브라우저가 httpOnly 쿠키로 자동 저장함 (localStorage 저장 X)
                 window.location.href = '/';
             } else {
                 serverError.textContent = result?.message || `로그인 실패 (${res.status})`;

--- a/src/main/resources/templates/department/create.html
+++ b/src/main/resources/templates/department/create.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <title>Bizportal - 부서 편성(등록)</title>
 
-<!--    &lt;!&ndash; (선택) CSRF 메타: CSRF 켜져있을 때만 사용 &ndash;&gt;-->
-<!--    <meta name="_csrf" th:content="${_csrf.token}"/>-->
-<!--    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>-->
+    <!--    &lt;!&ndash; (선택) CSRF 메타: CSRF 켜져있을 때만 사용 &ndash;&gt;-->
+    <!--    <meta name="_csrf" th:content="${_csrf.token}"/>-->
+    <!--    <meta name="_csrf_header" th:content="${_csrf.headerName}"/>-->
 
     <style>
         :root{
@@ -209,6 +209,12 @@
         return (token && header) ? { token, header } : null;
     }
 
+    async function safeJson(res) {
+        const ct = res.headers.get("content-type") || "";
+        if (!ct.includes("application/json")) return {};
+        try { return await res.json(); } catch { return {}; }
+    }
+
     $("submitBtn").addEventListener("click", async () => {
         const depId = $("depId").value.trim();
         const depName = $("depName").value.trim();
@@ -220,10 +226,6 @@
 
         const headers = { "Content-Type": "application/json" };
 
-        // (선택) JWT를 localStorage에 저장해 쓰는 구조라면 자동 포함
-        const token = localStorage.getItem("accessToken");
-        if (token) headers["Authorization"] = "Bearer " + token;
-
         // (선택) CSRF 켜져있을 때만 자동 포함
         const csrf = getCsrf();
         if (csrf) headers[csrf.header] = csrf.token;
@@ -232,40 +234,48 @@
             const res = await fetch("/api/v1/admin/departments", {
                 method: "POST",
                 headers,
+                credentials: "include", // ✅ accessToken(httpOnly 쿠키) 자동 전송
                 body: JSON.stringify({ depId, depName })
             });
 
-            // 성공
-            if (res.ok) {
-                // 너희 ResponseDto 구조면 메시지 꺼내서 표시 가능
-                let msg = "부서 등록에 성공했습니다.";
-                setTimeout(() => {
-                    window.location.href = "/admin/departments/list";
-                }, 1000);
-                try {
-                    const data = await res.json();
-                    if (data?.message) msg = data.message;
-                } catch (e) {}
-                alert(msg);
-                // 필요하면 목록 페이지로 이동
-                // location.href = "/admin/departments";
-                $("depId").value = "";
-                $("depName").value = "";
-                showMsg(msg, true);
+            if (res.status === 401) {
+                showMsg("로그인이 필요합니다. 다시 로그인 해주세요.", false);
+                return;
+            }
+            if (res.status === 403) {
+                showMsg("권한이 없습니다. (COM_ADMIN만 가능)", false);
                 return;
             }
 
-            // 실패(권한/검증 등)
-            let errMsg = "요청 처리에 실패했습니다.";
-            try {
-                const data = await res.json();
-                if (data?.message) errMsg = data.message;
-            } catch (e) {
-                errMsg = `요청 실패 (HTTP ${res.status})`;
+            // 성공
+            if (res.ok) {
+                let msg = "부서 등록에 성공했습니다.";
+                const data = await safeJson(res);
+                if (data?.message) msg = data.message;
+
+                alert(msg);
+
+                $("depId").value = "";
+                $("depName").value = "";
+                showMsg(msg, true);
+
+                setTimeout(() => {
+                    window.location.href = "/admin/departments/list";
+                }, 1000);
+
+                return;
             }
+
+            // 실패(검증 등)
+            let errMsg = "요청 처리에 실패했습니다.";
+            const data = await safeJson(res);
+            if (data?.message) errMsg = data.message;
+            else errMsg = `요청 실패 (HTTP ${res.status})`;
+
             showMsg(errMsg, false);
 
         } catch (e) {
+            console.error(e);
             showMsg("서버 통신 오류가 발생했습니다.", false);
         }
     });

--- a/src/main/resources/templates/department/list.html
+++ b/src/main/resources/templates/department/list.html
@@ -139,16 +139,6 @@
 </div>
 
 <script>
-    // ✅ 토큰 저장 키 유연하게 탐색
-    function getAccessToken() {
-        return (
-            localStorage.getItem("accessToken") ||
-            localStorage.getItem("jwt") ||
-            sessionStorage.getItem("accessToken") ||
-            sessionStorage.getItem("jwt")
-        );
-    }
-
     function showToast(msg, type) {
         const toast = document.getElementById("toast");
         toast.className = "toast " + (type || "");
@@ -160,31 +150,30 @@
         }, 2500);
     }
 
+    async function safeJson(res) {
+        const ct = res.headers.get("content-type") || "";
+        if (!ct.includes("application/json")) return {};
+        try { return await res.json(); } catch { return {}; }
+    }
+
     async function loadDepartments() {
-        const token = getAccessToken();
         const tbody = document.getElementById("deptTbody");
         const emptyBox = document.getElementById("emptyBox");
 
         tbody.innerHTML = "";
         emptyBox.style.display = "none";
 
-        if (!token) {
-            emptyBox.style.display = "block";
-            emptyBox.textContent = "로그인이 필요합니다. (토큰 없음)";
-            return;
-        }
-
         const res = await fetch("/api/v1/admin/departments", {
             method: "GET",
+            credentials: "include", // ✅ accessToken 쿠키 자동 전송
             headers: {
-                "Authorization": "Bearer " + token,
                 "Accept": "application/json"
             }
         });
 
         if (res.status === 401) {
             emptyBox.style.display = "block";
-            emptyBox.textContent = "인증이 만료되었습니다. 다시 로그인 해주세요.";
+            emptyBox.textContent = "로그인이 필요합니다. 다시 로그인 해주세요.";
             return;
         }
         if (res.status === 403) {
@@ -198,7 +187,7 @@
             return;
         }
 
-        const json = await res.json();
+        const json = await safeJson(res);
         const list = json.data || [];
 
         if (!list.length) {
@@ -208,7 +197,6 @@
         }
 
         list.forEach(d => {
-            // ✅ depNo가 있으면 그걸 쓰고, 없으면 depId를 fallback
             const depNo = d.depNo;
             const depId = d.depId ?? "";
             const depName = d.depName ?? "";
@@ -231,33 +219,25 @@
         });
     }
 
-    // ✅ 수정 페이지 이동 (서버 컨트롤러가 /{depNo}/edit 형태라서 depNo 사용)
     function onEdit(depNo) {
         location.href = `/admin/departments/${depNo}/edit`;
     }
 
-    // ✅ 삭제 기능 (DELETE API 호출)
     async function onDelete(depNo, depName) {
-        const token = getAccessToken();
-        if (!token) {
-            showToast("로그인이 필요합니다. (토큰 없음)", "err");
-            return;
-        }
-
         const ok = confirm(`정말로 '${depName}' 부서를 삭제할까요?\n(삭제 후 복구 불가)`);
         if (!ok) return;
 
         try {
             const res = await fetch(`/api/v1/admin/departments/${depNo}`, {
                 method: "DELETE",
+                credentials: "include", // ✅ accessToken 쿠키 자동 전송
                 headers: {
-                    "Authorization": "Bearer " + token,
                     "Accept": "application/json"
                 }
             });
 
             if (res.status === 401) {
-                showToast("인증이 만료되었습니다. 다시 로그인 해주세요.", "err");
+                showToast("로그인이 필요합니다. 다시 로그인 해주세요.", "err");
                 return;
             }
             if (res.status === 403) {
@@ -266,14 +246,11 @@
             }
 
             if (!res.ok) {
-                // 서버가 에러 메시지를 내려주면 출력 시도
                 let msg = `삭제 실패 (${res.status})`;
-                try {
-                    const json = await res.json();
-                    if (json && (json.message || json.error)) {
-                        msg = json.message || json.error;
-                    }
-                } catch (_) {}
+                const json = await safeJson(res);
+                if (json && (json.message || json.error)) {
+                    msg = json.message || json.error;
+                }
                 showToast(msg, "err");
                 return;
             }
@@ -286,7 +263,6 @@
         }
     }
 
-    // XSS 방지
     function escapeHtml(str) {
         return String(str)
             .replaceAll("&","&amp;")

--- a/src/main/resources/templates/department/update.html
+++ b/src/main/resources/templates/department/update.html
@@ -118,7 +118,7 @@
     <div class="user-actions">
         <div class="icon-circle">🔔</div>
         <div class="icon-circle">👤</div>
-        <button class="btn-logout" type="button">로그아웃</button>
+        <button class="btn-logout" id="logoutBtn" type="button">로그아웃</button>
     </div>
 </div>
 
@@ -181,6 +181,31 @@
         setTimeout(() => { el.style.display = "none"; }, 3000);
     }
 
+    async function safeJson(res) {
+        const ct = res.headers.get("content-type") || "";
+        if (!ct.includes("application/json")) return {};
+        try { return await res.json(); } catch { return {}; }
+    }
+
+    // (선택) 로그아웃 버튼 - 쿠키 기반이면 보통 POST /auth/logout 같은 API 호출로 처리
+    // 프로젝트 라우팅에 맞춰 경로만 바꿔서 쓰면 됨
+    document.getElementById("logoutBtn").addEventListener("click", async () => {
+        try {
+            // 예: 백엔드에 POST /auth/logout 구현되어 있다면
+            const res = await fetch("/auth/logout", {
+                method: "POST",
+                credentials: "include"
+            });
+
+            // 성공/실패와 상관없이 쿠키 삭제 헤더 내려주게 해둔 상태라면
+            // 프론트는 그냥 로그인 페이지나 메인으로 이동시키면 됨
+            location.href = "/auth/companies/login";
+        } catch (e) {
+            console.error(e);
+            location.href = "/auth/companies/login";
+        }
+    });
+
     // 수정 완료 버튼 클릭 이벤트
     document.getElementById("submitBtn").addEventListener("click", async () => {
         const depNo = document.getElementById("depNo").value;
@@ -192,38 +217,39 @@
             return;
         }
 
-        // 로컬 스토리지에서 JWT 토큰 획득
-        const token = localStorage.getItem("accessToken");
-
-        if (!token) {
-            showStatus("세션이 만료되었습니다. 다시 로그인해주세요.", false);
-            return;
-        }
-
         const payload = { depId, depName };
 
         try {
             const response = await fetch(`${API_URL}/${depNo}`, {
                 method: "PUT",
                 headers: {
-                    "Content-Type": "application/json",
-                    "Authorization": `Bearer ${token}` // JWT 인증 헤더 포함
+                    "Content-Type": "application/json"
                 },
+                credentials: "include", // ✅ httpOnly 쿠키(accessToken) 자동 포함
                 body: JSON.stringify(payload)
             });
 
             if (response.ok) {
                 showStatus("부서 정보가 성공적으로 반영되었습니다.", true);
-                // 성공 시 1초 후 목록 페이지로 자동 이동
                 setTimeout(() => {
                     window.location.href = "/admin/departments/list";
                 }, 1000);
-            } else if (response.status === 403) {
-                showStatus("수정 권한이 없습니다 (관리자 전용).", false);
-            } else {
-                const errorData = await response.json();
-                showStatus(errorData.message || "수정 처리 중 오류가 발생했습니다.", false);
+                return;
             }
+
+            if (response.status === 401) {
+                showStatus("로그인이 필요합니다. 다시 로그인해주세요.", false);
+                return;
+            }
+
+            if (response.status === 403) {
+                showStatus("수정 권한이 없습니다 (관리자 전용).", false);
+                return;
+            }
+
+            const errorData = await safeJson(response);
+            showStatus(errorData.message || `수정 처리 중 오류가 발생했습니다. (HTTP ${response.status})`, false);
+
         } catch (error) {
             console.error("Fetch Error:", error);
             showStatus("네트워크 오류가 발생했습니다. 잠시 후 다시 시도해주세요.", false);

--- a/src/main/resources/templates/employee/common/login.html
+++ b/src/main/resources/templates/employee/common/login.html
@@ -179,6 +179,12 @@
     const form = document.getElementById('employee-login-form');
     const serverError = document.getElementById('serverError');
 
+    async function safeJson(res) {
+        const ct = res.headers.get('content-type') || '';
+        if (!ct.includes('application/json')) return {};
+        try { return await res.json(); } catch { return {}; }
+    }
+
     form.addEventListener('submit', async (e) => {
         e.preventDefault();
         serverError.style.display = 'none';
@@ -191,19 +197,19 @@
             const res = await fetch('/auth/employee/login', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
+                credentials: 'include', // ✅ Set-Cookie(AT/RT)를 저장/전송하기 위해
                 body: JSON.stringify({ empId, password })
             });
 
-            const result = await res.json();
+            const result = await safeJson(res);
 
             if (res.ok) {
-                const accessToken = result?.data?.accessToken;
-                if (accessToken) localStorage.setItem('accessToken', accessToken);
-
+                // ✅ accessToken/refreshToken은 서버가 Set-Cookie로 내려주면
+                // 브라우저가 httpOnly 쿠키로 자동 저장함 (localStorage 저장 X)
                 alert(result?.message || '로그인 성공!');
                 window.location.href = '/';
             } else {
-                serverError.textContent = result?.message || '로그인에 실패했습니다.';
+                serverError.textContent = result?.message || `로그인에 실패했습니다. (${res.status})`;
                 serverError.style.display = 'block';
             }
         } catch (err) {

--- a/src/main/resources/templates/positions/create.html
+++ b/src/main/resources/templates/positions/create.html
@@ -129,15 +129,6 @@
         select.value = "1"; // 기본값
     })();
 
-    function getAccessToken() {
-        return (
-            localStorage.getItem("accessToken") ||
-            localStorage.getItem("jwt") ||
-            sessionStorage.getItem("accessToken") ||
-            sessionStorage.getItem("jwt")
-        );
-    }
-
     function showMsg(type, text) {
         const el = document.getElementById("msg");
         el.style.display = "block";
@@ -145,15 +136,16 @@
         el.textContent = text;
     }
 
+    async function safeJson(res) {
+        const ct = res.headers.get("content-type") || "";
+        if (!ct.includes("application/json")) return {};
+        try { return await res.json(); } catch { return {}; }
+    }
+
     async function submitCreate() {
-        const token = getAccessToken();
         const posName = document.getElementById("posName").value.trim();
         const posOrder = parseInt(document.getElementById("posOrder").value, 10);
 
-        if (!token) {
-            showMsg("err", "로그인이 필요합니다. (토큰 없음)");
-            return;
-        }
         if (!posName) {
             showMsg("err", "직급명을 입력하세요.");
             return;
@@ -163,37 +155,41 @@
             return;
         }
 
-        const res = await fetch("/api/v1/admin/positions", {
-            method: "POST",
-            headers: {
-                "Authorization": "Bearer " + token,
-                "Content-Type": "application/json",
-                "Accept": "application/json"
-            },
-            body: JSON.stringify({ posName, posOrder })
-        });
+        try {
+            const res = await fetch("/api/v1/admin/positions", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                    "Accept": "application/json"
+                },
+                credentials: "include", // ✅ httpOnly 쿠키(accessToken) 자동 전송
+                body: JSON.stringify({ posName, posOrder })
+            });
 
-        if (res.status === 401) {
-            showMsg("err", "인증이 만료되었습니다. 다시 로그인 해주세요.");
-            return;
-        }
-        if (res.status === 403) {
-            showMsg("err", "권한이 없습니다. (COM_ADMIN만 가능)");
-            return;
-        }
+            if (res.status === 401) {
+                showMsg("err", "로그인이 필요합니다. 다시 로그인 해주세요.");
+                return;
+            }
+            if (res.status === 403) {
+                showMsg("err", "권한이 없습니다. (COM_ADMIN만 가능)");
+                return;
+            }
 
-        if (!res.ok) {
-            let msg = "직급 등록 중 오류가 발생했습니다. (" + res.status + ")";
-            try {
-                const json = await res.json();
+            if (!res.ok) {
+                let msg = "직급 등록 중 오류가 발생했습니다. (" + res.status + ")";
+                const json = await safeJson(res);
                 if (json && (json.message || json.msg)) msg = json.message || json.msg;
-            } catch(e) {}
-            showMsg("err", msg);
-            return;
-        }
+                showMsg("err", msg);
+                return;
+            }
 
-        showMsg("ok", "직급이 등록되었습니다.");
-        setTimeout(() => location.href = "/admin/positions/list", 300);
+            showMsg("ok", "직급이 등록되었습니다.");
+            setTimeout(() => location.href = "/admin/positions/list", 300);
+
+        } catch (e) {
+            console.error(e);
+            showMsg("err", "서버 통신 오류가 발생했습니다.");
+        }
     }
 </script>
 </body>

--- a/src/main/resources/templates/positions/list.html
+++ b/src/main/resources/templates/positions/list.html
@@ -275,15 +275,6 @@
 <div id="toast" class="toast" aria-live="polite"></div>
 
 <script>
-    function getAccessToken() {
-        return (
-            localStorage.getItem("accessToken") ||
-            localStorage.getItem("jwt") ||
-            sessionStorage.getItem("accessToken") ||
-            sessionStorage.getItem("jwt")
-        );
-    }
-
     // ===== Toast =====
     let toastTimer = null;
     function showToast(type, text) {
@@ -316,31 +307,28 @@
         if (e.target.id === "confirmBackdrop") closeConfirm();
     });
 
+    async function safeJson(res) {
+        const ct = res.headers.get("content-type") || "";
+        if (!ct.includes("application/json")) return {};
+        try { return await res.json(); } catch { return {}; }
+    }
+
     async function loadPositions() {
-        const token = getAccessToken();
         const tbody = document.getElementById("posTbody");
         const emptyBox = document.getElementById("emptyBox");
 
         tbody.innerHTML = "";
         emptyBox.style.display = "none";
 
-        if (!token) {
-            emptyBox.style.display = "block";
-            emptyBox.textContent = "로그인이 필요합니다. (토큰 없음)";
-            return;
-        }
-
         const res = await fetch("/api/v1/admin/positions", {
             method: "GET",
-            headers: {
-                "Authorization": "Bearer " + token,
-                "Accept": "application/json"
-            }
+            headers: { "Accept": "application/json" },
+            credentials: "include" // ✅ httpOnly 쿠키(accessToken) 자동 전송
         });
 
         if (res.status === 401) {
             emptyBox.style.display = "block";
-            emptyBox.textContent = "인증이 만료되었습니다. 다시 로그인 해주세요.";
+            emptyBox.textContent = "로그인이 필요합니다. 다시 로그인 해주세요.";
             return;
         }
         if (res.status === 403) {
@@ -354,7 +342,7 @@
             return;
         }
 
-        const json = await res.json();
+        const json = await safeJson(res);
         const list = json.data || [];
 
         if (!list.length) {
@@ -399,11 +387,6 @@
 
     // ✅ 삭제 버튼 클릭 -> 모달 오픈
     function onDeleteClick(posNo, posName) {
-        const token = getAccessToken();
-        if (!token) {
-            showToast("err", "로그인이 필요합니다. (토큰 없음)");
-            return;
-        }
         openConfirm(posNo, posName);
     }
 
@@ -412,25 +395,17 @@
         if (!pendingDelete) return;
 
         const { posNo, posName } = pendingDelete;
-        const token = getAccessToken();
-        if (!token) {
-            closeConfirm();
-            showToast("err", "로그인이 필요합니다. (토큰 없음)");
-            return;
-        }
 
         try {
             const res = await fetch(`/api/v1/admin/positions/${posNo}`, {
                 method: "DELETE",
-                headers: {
-                    "Authorization": "Bearer " + token,
-                    "Accept": "application/json"
-                }
+                headers: { "Accept": "application/json" },
+                credentials: "include" // ✅ httpOnly 쿠키(accessToken) 자동 전송
             });
 
             if (res.status === 401) {
                 closeConfirm();
-                showToast("err", "인증이 만료되었습니다. 다시 로그인 해주세요.");
+                showToast("err", "로그인이 필요합니다. 다시 로그인 해주세요.");
                 return;
             }
             if (res.status === 403) {
@@ -441,10 +416,8 @@
 
             if (!res.ok) {
                 let msg = `직급 삭제 중 오류가 발생했습니다. (${res.status})`;
-                try {
-                    const json = await res.json();
-                    if (json && (json.message || json.msg)) msg = json.message || json.msg;
-                } catch (e) {}
+                const json = await safeJson(res);
+                if (json && (json.message || json.msg)) msg = json.message || json.msg;
                 closeConfirm();
                 showToast("err", msg);
                 return;

--- a/src/main/resources/templates/positions/update.html
+++ b/src/main/resources/templates/positions/update.html
@@ -66,7 +66,7 @@
         .form-control {
             width: 100%; height: 56px; border-radius: 14px; border: 1px solid #ddd;
             padding: 0 20px; font-size: 16px; transition: all 0.2s ease;
-            background: #fff; appearance: none; /* 브라우저 기본 화살표 제거 (필요시) */
+            background: #fff; appearance: none;
         }
         select.form-control {
             background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='%23777' viewBox='0 0 16 16'%3E%3Cpath d='M7.247 11.14 2.451 5.658C1.885 5.013 2.345 4 3.204 4h9.592a1 1 0 0 1 .753 1.659l-4.796 5.48a1 1 0 0 1-1.506 0z'/%3E%3C/svg%3E");
@@ -159,10 +159,6 @@
 <script th:inline="javascript">
     const API_BASE = "/api/v1/admin/positions";
 
-    function getAccessToken() {
-        return localStorage.getItem("accessToken") || localStorage.getItem("token");
-    }
-
     function showStatus(isOk, text) {
         const el = document.getElementById("statusMsg");
         el.textContent = text;
@@ -170,29 +166,29 @@
         el.style.display = "block";
     }
 
+    async function safeJson(res) {
+        const ct = res.headers.get("content-type") || "";
+        if (!ct.includes("application/json")) return {};
+        try { return await res.json(); } catch { return {}; }
+    }
+
     async function submitUpdate() {
         const posNo = document.getElementById("posNo").value;
         const posName = document.getElementById("posName").value.trim();
-        const posOrder = document.getElementById("posOrder").value; // ✅ 드롭다운 값 읽기
-        const token = getAccessToken();
-
+        const posOrder = document.getElementById("posOrder").value; // 드롭다운 값
         if (!posNo) { showStatus(false, "직급 번호를 찾을 수 없습니다."); return; }
         if (!posName) { showStatus(false, "직급명을 입력해주세요."); return; }
-        if (!token) { showStatus(false, "인증 정보가 없습니다."); return; }
 
-        // ✅ 백엔드 DTO 필드명(posName, posOrder)에 맞춰 페이로드 구성
         const payload = {
             posName: posName,
-            posOrder: parseInt(posOrder) // 숫자로 변환하여 전송
+            posOrder: parseInt(posOrder, 10)
         };
 
         try {
             const response = await fetch(`${API_BASE}/${posNo}`, {
                 method: "PUT",
-                headers: {
-                    "Content-Type": "application/json",
-                    "Authorization": `Bearer ${token}`
-                },
+                headers: { "Content-Type": "application/json" },
+                credentials: "include",          // ✅ httpOnly 쿠키(accessToken) 자동 전송
                 body: JSON.stringify(payload)
             });
 
@@ -201,10 +197,20 @@
                 setTimeout(() => {
                     location.href = "/admin/positions/list";
                 }, 1000);
-            } else {
-                const data = await response.json().catch(() => ({}));
-                showStatus(false, data.message || "수정 처리 중 오류가 발생했습니다.");
+                return;
             }
+
+            if (response.status === 401) {
+                showStatus(false, "로그인이 필요합니다. 다시 로그인 해주세요.");
+                return;
+            }
+            if (response.status === 403) {
+                showStatus(false, "수정 권한이 없습니다 (관리자 전용).");
+                return;
+            }
+
+            const data = await safeJson(response);
+            showStatus(false, data.message || data.msg || "수정 처리 중 오류가 발생했습니다.");
         } catch (error) {
             console.error("Fetch Error:", error);
             showStatus(false, "서버 연결 실패. 네트워크를 확인하세요.");


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #172

## 📝 작업 내용
- accesstoken 전송 방식 httpOnly Cookie로 변경
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
