### PR TITLE
[feat] 권한별 페이지 접근 제한 추가

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/DocumentFormStatsConverter.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/DocumentFormStatsConverter.java
@@ -1,0 +1,27 @@
+package com.multi.mlpenterpriseapprovalsystem.document_form.form;
+
+import com.multi.mlpenterpriseapprovalsystem.document_form.form.enums.*;
+import jakarta.persistence.*;
+
+/**
+ * 스탯 코드를 문자로 치환
+ *
+ * @author : 정종원
+ * @filename : DocumentFormStatsConverter
+ * @since : 2025-12-30 화요일
+ */
+
+@Converter(autoApply = false)
+public class DocumentFormStatsConverter
+        implements AttributeConverter<DocumentFormStats, String> {
+
+    @Override
+    public String convertToDatabaseColumn(DocumentFormStats attribute) {
+        return attribute == null ? null : attribute.name(); // 항상 1글자
+    }
+
+    @Override
+    public DocumentFormStats convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : DocumentFormStats.valueOf(dbData);
+    }
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/controller/DocumentFormController.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/controller/DocumentFormController.java
@@ -69,14 +69,16 @@ public class DocumentFormController {
     @GetMapping
     public ResponseEntity<Page<ResDocumentFormListDto>> getForms(
             @AuthenticationPrincipal CustomUser customUser,
-            @RequestParam(name = "stat", defaultValue = "A") DocumentFormStats stat,
+            @RequestParam(name = "stat", defaultValue = "A") java.util.List<DocumentFormStats> stat,
             @RequestParam(name = "q", required = false) String q,
             @RequestParam(name = "docfoName", required = false) String docfoName,
             @PageableDefault(size = 15) Pageable pageable
     ) {
         String keyword = (q != null && !q.isBlank()) ? q : docfoName;
+
+        // stat=A,X 처럼 오면 List로 자동 바인딩됨 (Spring MVC 기본 동작)
         return ResponseEntity.ok(
-                documentFormService.findListByStatus(stat, customUser.getComId(), keyword, pageable)
+                documentFormService.findListByStatuses(stat, customUser.getComId(), keyword, pageable)
         );
     }
 

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/controller/DocumentFormController.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/controller/DocumentFormController.java
@@ -37,9 +37,7 @@ public class DocumentFormController {
             @RequestBody ReqDocumentFormCreateDto req
     ) {
         Long docfoNo = documentFormService.createDocumentForm(
-                req,
-                customUser.getComId(),
-                customUser.getUsername()
+                req, customUser.getComId(), customUser.getUsername()
         );
         return ResponseEntity.status(HttpStatus.CREATED).body(docfoNo);
     }
@@ -52,29 +50,22 @@ public class DocumentFormController {
             @RequestBody ReqDocumentFormCreateDto req
     ) {
         Long newDocfoNo = documentFormService.updateDocumentForm(
-                docfoNo,
-                req,
-                customUser.getComId(),
-                customUser.getUsername()
+                docfoNo, req, customUser.getComId(), customUser.getUsername()
         );
         return ResponseEntity.ok(newDocfoNo);
     }
 
+    // 삭제 "요청" (W로 전환)
     @PreAuthorize("hasAnyRole('COM_ADMIN','SEC_ADMIN','THR_ADMIN')")
     @DeleteMapping("/{docfoNo}")
-    public ResponseEntity<Void> deleteDocumentForm(
+    public ResponseEntity<Void> requestDelete(
             @AuthenticationPrincipal CustomUser customUser,
             @PathVariable Long docfoNo
     ) {
-        documentFormService.deleteDocumentForm(docfoNo, customUser.getComId());
+        documentFormService.requestDelete(docfoNo, customUser.getComId(), customUser);
         return ResponseEntity.noContent().build();
     }
 
-    /**
-     * 회사별 + 상태별 목록 조회 (+ 제목 검색)
-     * - stat: A/P/R/T/D 등
-     * - q 또는 docfoName: 제목 키워드 검색(Containing)
-     */
     @GetMapping
     public ResponseEntity<Page<ResDocumentFormListDto>> getForms(
             @AuthenticationPrincipal CustomUser customUser,
@@ -84,7 +75,6 @@ public class DocumentFormController {
             @PageableDefault(size = 15) Pageable pageable
     ) {
         String keyword = (q != null && !q.isBlank()) ? q : docfoName;
-
         return ResponseEntity.ok(
                 documentFormService.findListByStatus(stat, customUser.getComId(), keyword, pageable)
         );
@@ -93,37 +83,55 @@ public class DocumentFormController {
     @GetMapping("/{docfoNo}")
     public ResponseEntity<ResDocumentFormDetailDto> getDocumentForm(
             @AuthenticationPrincipal CustomUser customUser,
-            @PathVariable(name = "docfoNo") Long docfoNo
+            @PathVariable Long docfoNo
     ) {
-        ResDocumentFormDetailDto result =
-                documentFormService.findDetailById(docfoNo, customUser.getComId());
-        return ResponseEntity.ok(result);
+        return ResponseEntity.ok(
+                documentFormService.findDetailById(docfoNo, customUser.getComId())
+        );
     }
 
-    /**
-     * 승인/반려 상태 변경
-     * - PATCH /api/v1/forms/{docfoNo}/status
-     * - body: { "docfoStat":"A" }
-     * - body: { "docfoStat":"R", "rejectReason":"..." }
-     */
+    // 상태 변경
     @PreAuthorize("hasAnyRole('COM_ADMIN','SEC_ADMIN')")
     @PatchMapping("/{docfoNo}/status")
     public ResponseEntity<Void> changeStatus(
             @AuthenticationPrincipal CustomUser customUser,
-            @PathVariable(name = "docfoNo") Long docfoNo,
+            @PathVariable Long docfoNo,
             @RequestBody ReqDocumentFormStatusDto req
     ) {
-        if (req == null || req.docfoStat() == null) {
-            return ResponseEntity.badRequest().build();
-        }
+        if (req == null || req.docfoStat() == null) return ResponseEntity.badRequest().build();
 
-        documentFormService.changeStatus(
+        documentFormService.changeApproveOrReject(
                 docfoNo,
                 customUser.getComId(),
                 req.docfoStat(),
                 req.rejectReason()
         );
+        return ResponseEntity.noContent().build();
+    }
 
+    // 삭제 승인
+    @PreAuthorize("hasAnyRole('COM_ADMIN','SEC_ADMIN')")
+    @PatchMapping("/{docfoNo}/delete-approve")
+    public ResponseEntity<Void> approveDelete(
+            @AuthenticationPrincipal CustomUser customUser,
+            @PathVariable Long docfoNo
+    ) {
+        documentFormService.approveDelete(docfoNo, customUser.getComId());
+        return ResponseEntity.noContent().build();
+    }
+
+    // 삭제 반려
+    @PreAuthorize("hasAnyRole('COM_ADMIN','SEC_ADMIN')")
+    @PatchMapping("/{docfoNo}/delete-reject")
+    public ResponseEntity<Void> rejectDelete(
+            @AuthenticationPrincipal CustomUser customUser,
+            @PathVariable Long docfoNo,
+            @RequestBody ReqDocumentFormStatusDto req
+    ) {
+        if (req == null || req.rejectReason() == null || req.rejectReason().isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        documentFormService.rejectDelete(docfoNo, customUser.getComId(), req.rejectReason());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/controller/ViewDocumentFormController.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/controller/ViewDocumentFormController.java
@@ -1,6 +1,7 @@
 package com.multi.mlpenterpriseapprovalsystem.document_form.form.controller;
 
 import lombok.*;
+import org.springframework.security.access.prepost.*;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,22 +23,26 @@ import org.springframework.web.bind.annotation.RequestParam;
 @RequiredArgsConstructor
 public class ViewDocumentFormController {
 
+    @PreAuthorize("hasAnyRole('SYS_ADMIN','COM_ADMIN','SEC_ADMIN','THR_ADMIN','EMPLOYEE')")
     @GetMapping("/forms")
     public String formList() {
         return "document-form/form-list";
     }
 
+    @PreAuthorize("hasAnyRole('SYS_ADMIN','COM_ADMIN','SEC_ADMIN','THR_ADMIN','EMPLOYEE')")
     @GetMapping("/{docfoNo}")
     public String formDetail(@PathVariable Long docfoNo, Model model) {
         model.addAttribute("docfoNo", docfoNo);
         return "document-form/detail";
     }
 
+    @PreAuthorize("hasAnyRole('SYS_ADMIN','COM_ADMIN','SEC_ADMIN','THR_ADMIN')")
     @GetMapping("/new")
     public String createForm() {
         return "document-form/make-form";
     }
 
+    @PreAuthorize("hasAnyRole('SYS_ADMIN','COM_ADMIN','SEC_ADMIN','THR_ADMIN')")
     @GetMapping("/{docfoNo}/edit")
     public String updateForm(@PathVariable Long docfoNo, Model model) {
         model.addAttribute("docfoNo", docfoNo);

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/domain/DocumentForm.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/domain/DocumentForm.java
@@ -1,6 +1,7 @@
 package com.multi.mlpenterpriseapprovalsystem.document_form.form.domain;
 
 import com.multi.mlpenterpriseapprovalsystem.company.domain.Company;
+import com.multi.mlpenterpriseapprovalsystem.document_form.form.*;
 import com.multi.mlpenterpriseapprovalsystem.document_form.form.enums.*;
 import com.multi.mlpenterpriseapprovalsystem.employee.domain.Employee;
 import jakarta.persistence.*;
@@ -55,10 +56,11 @@ public class DocumentForm {
     @Column(nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
-    @Column(nullable = false, length = 1)
-    @Enumerated(EnumType.STRING)
-    private DocumentFormStats docfoStat; // T, P, R, A, D
+    @Column(name = "docfo_stat", nullable = false, columnDefinition = "char(1)")
+    @Convert(converter = DocumentFormStatsConverter.class)
+    private DocumentFormStats docfoStat;
 
+    @Column(name = "reject_reason")
     private String rejectReason;
 
     public static DocumentForm create(

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/domain/DocumentForm.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/domain/DocumentForm.java
@@ -74,7 +74,7 @@ public class DocumentForm {
         f.docfoName = docfoName;
         f.cnttJson = cnttJson;
         f.cnttHtml = cnttHtml;
-        f.docfoStat = DocumentFormStats.P; // 승인 로직 개발 후 T로 수정
+        f.docfoStat = DocumentFormStats.P;
         return f;
     }
 

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/enums/DocumentFormStats.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/enums/DocumentFormStats.java
@@ -13,5 +13,7 @@ public enum DocumentFormStats {
     P, // 대기
     R, // 반려
     A, // 승인
-    D  // 삭제
+    D, // 삭제
+    W, // 삭제대기
+    X  // 삭제반려
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/repository/DocumentFormRepository.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/repository/DocumentFormRepository.java
@@ -33,6 +33,18 @@ public interface DocumentFormRepository extends JpaRepository<DocumentForm, Long
 
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("""
+        update DocumentForm f
+           set f.docfoStat = :stat,
+               f.rejectReason = :reason
+         where f.docfoNo = :docfoNo
+    """)
+    int updateStatusAndReason(@Param("docfoNo") Long docfoNo,
+                              @Param("stat") DocumentFormStats stat,
+                              @Param("reason") String reason);
+
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
         update DocumentForm d
            set d.docfoStat = :stat
          where d.docfoNo = :docfoNo

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/repository/DocumentFormRepository.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/repository/DocumentFormRepository.java
@@ -42,22 +42,16 @@ public interface DocumentFormRepository extends JpaRepository<DocumentForm, Long
                               @Param("stat") DocumentFormStats stat,
                               @Param("reason") String reason);
 
+    Page<DocumentForm> findByDocfoStatInAndCompany_ComIdOrderByDocfoNoAsc(
+            java.util.List<DocumentFormStats> stats,
+            String comId,
+            Pageable pageable
+    );
 
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("""
-        update DocumentForm d
-           set d.docfoStat = :stat
-         where d.docfoNo = :docfoNo
-    """)
-    int updateDocfoStat(@Param("docfoNo") Long docfoNo,
-                        @Param("stat") DocumentFormStats stat);
-
-    @Modifying(clearAutomatically = true, flushAutomatically = true)
-    @Query("""
-        update DocumentForm d
-           set d.rejectReason = :rejectReason
-         where d.docfoNo = :docfoNo
-    """)
-    int updateRejectReason(@Param("docfoNo") Long docfoNo,
-                           @Param("rejectReason") String rejectReason);
+    Page<DocumentForm> findByDocfoStatInAndCompany_ComIdAndDocfoNameContainingIgnoreCaseOrderByDocfoNoAsc(
+            java.util.List<DocumentFormStats> stats,
+            String comId,
+            String docfoName,
+            Pageable pageable
+    );
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/service/DocumentFormService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/service/DocumentFormService.java
@@ -36,7 +36,11 @@ public interface DocumentFormService {
             String writerId
     );
 
-    void deleteDocumentForm(Long docfoNo, String comId);
+    // 삭제 플로우
+    void requestDelete(Long docfoNo, String comId, CustomUser requester);
+    void approveDelete(Long docfoNo, String comId);
+    void rejectDelete(Long docfoNo, String comId, String rejectReason);
 
-    void changeStatus(Long docfoNo, String comId, DocumentFormStats stat, String rejectReason);
+    // 승인/반려
+    void changeApproveOrReject(Long docfoNo, String comId, DocumentFormStats next, String rejectReason);
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/service/DocumentFormService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/service/DocumentFormService.java
@@ -18,8 +18,8 @@ import org.springframework.data.domain.Pageable;
 
 public interface DocumentFormService {
 
-    Page<ResDocumentFormListDto> findListByStatus(
-            DocumentFormStats stat,
+    Page<ResDocumentFormListDto> findListByStatuses(
+            java.util.List<DocumentFormStats> stats,
             String comId,
             String keyword,
             Pageable pageable

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/service/DocumentFormServiceImpl.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/service/DocumentFormServiceImpl.java
@@ -39,14 +39,10 @@ public class DocumentFormServiceImpl implements DocumentFormService {
     private final CompanyRepository companyRepository;
     private final EmployeeRepository employeeRepository;
 
-    // 목록 조회 (+ 제목 검색 옵션)
     @Override
     @Transactional(readOnly = true)
     public Page<ResDocumentFormListDto> findListByStatus(
-            DocumentFormStats stat,
-            String comId,
-            String keyword,
-            Pageable pageable
+            DocumentFormStats stat, String comId, String keyword, Pageable pageable
     ) {
         boolean hasKeyword = (keyword != null && !keyword.isBlank());
 
@@ -68,7 +64,6 @@ public class DocumentFormServiceImpl implements DocumentFormService {
         ));
     }
 
-    // 상세 조회
     @Override
     @Transactional(readOnly = true)
     public ResDocumentFormDetailDto findDetailById(Long docfoNo, String comId) {
@@ -94,14 +89,9 @@ public class DocumentFormServiceImpl implements DocumentFormService {
         );
     }
 
-    // 생성
     @Override
     @Transactional
-    public Long createDocumentForm(
-            ReqDocumentFormCreateDto req,
-            String comId,
-            String writerId
-    ) {
+    public Long createDocumentForm(ReqDocumentFormCreateDto req, String comId, String writerId) {
         Company company = companyRepository.findByComId(comId)
                 .orElseThrow(() -> new EntityNotFoundException("회사 없음"));
 
@@ -114,7 +104,7 @@ public class DocumentFormServiceImpl implements DocumentFormService {
                 req.docfoName(),
                 ensureJsonString(req.cnttJson()),
                 null
-        ); // create() 안에서 P로 설정됨
+        );
 
         DocumentForm saved = documentFormRepository.save(form);
 
@@ -133,22 +123,16 @@ public class DocumentFormServiceImpl implements DocumentFormService {
         return saved.getDocfoNo();
     }
 
-    // 수정
     @Override
     @Transactional
-    public Long updateDocumentForm(
-            Long docfoNo,
-            ReqDocumentFormCreateDto req,
-            String comId,
-            String empId
-    ) {
+    public Long updateDocumentForm(Long docfoNo, ReqDocumentFormCreateDto req, String comId, String empId) {
         DocumentForm origin = documentFormRepository.findById(docfoNo)
                 .orElseThrow(() -> new IllegalArgumentException("문서 양식 없음"));
 
         validateCompany(origin, comId);
 
-        // 기존 문서 삭제 처리
-        documentFormRepository.updateDocfoStat(origin.getDocfoNo(), DocumentFormStats.D);
+        // 기존 문서 삭제 처리(논리삭제)
+        documentFormRepository.updateStatusAndReason(origin.getDocfoNo(), DocumentFormStats.D, null);
 
         Employee writer = employeeRepository.findByEmpId(empId)
                 .orElseThrow(() -> new IllegalArgumentException("작성자 정보 없음"));
@@ -161,85 +145,114 @@ public class DocumentFormServiceImpl implements DocumentFormService {
                 req.cnttHtml()
         );
 
-        documentFormRepository.save(newForm);
+        DocumentForm saved = documentFormRepository.save(newForm);
 
         if (req.categories() != null && !req.categories().isEmpty()) {
             List<DocumentFormCategory> categories =
                     req.categories().stream()
-                            .map(name -> DocumentFormCategory.create(
-                                    origin.getCompany(),
-                                    newForm,
-                                    name
-                            ))
+                            .map(String::trim)
+                            .filter(s -> !s.isEmpty())
+                            .distinct()
+                            .map(name -> DocumentFormCategory.create(origin.getCompany(), saved, name))
                             .toList();
 
             documentFormCategoryRepository.saveAll(categories);
         }
 
-        return newForm.getDocfoNo();
+        return saved.getDocfoNo();
     }
 
-    // 삭제
+    // 승인/반려(A/R) 전용
     @Override
     @Transactional
-    public void deleteDocumentForm(Long docfoNo, String comId) {
+    public void changeApproveOrReject(Long docfoNo, String comId, DocumentFormStats next, String rejectReason) {
+        if (next != DocumentFormStats.A && next != DocumentFormStats.R) {
+            throw new IllegalArgumentException("A(승인) 또는 R(반려)만 가능합니다.");
+        }
+
         DocumentForm form = documentFormRepository.findById(docfoNo)
                 .orElseThrow(() -> new EntityNotFoundException("DocumentForm not found"));
 
         validateCompany(form, comId);
 
-        documentFormRepository.updateDocfoStat(docfoNo, DocumentFormStats.D);
-    }
+        DocumentFormStats cur = form.getDocfoStat();
 
-    // 승인 / 반려
+        if (cur == DocumentFormStats.D || cur == DocumentFormStats.W || cur == DocumentFormStats.X) {
+            throw new IllegalStateException("삭제 흐름 상태에서는 승인/반려를 변경할 수 없습니다.");
+        }
+
+        // R/X가 아니면 null로 만드는 규칙 강제
+        String normalized = normalizeRejectReason(next, rejectReason);
+
+        documentFormRepository.updateStatusAndReason(docfoNo, next, normalized);
+    }
+    // 삭제 플로우
     @Override
     @Transactional
-    public void changeStatus(
-            Long docfoNo,
-            String comId,
-            DocumentFormStats stat,
-            String rejectReason
-    ) {
+    public void requestDelete(Long docfoNo, String comId, CustomUser requester) {
         DocumentForm form = documentFormRepository.findById(docfoNo)
                 .orElseThrow(() -> new EntityNotFoundException("DocumentForm not found"));
 
         validateCompany(form, comId);
 
-        if (stat != DocumentFormStats.A && stat != DocumentFormStats.R) {
-            throw new IllegalArgumentException("허용되지 않은 상태 변경");
-        }
+        // 이미 삭제/삭제대기면 불가
+        if (form.getDocfoStat() == DocumentFormStats.D) throw new IllegalStateException("이미 삭제된 양식입니다.");
+        if (form.getDocfoStat() == DocumentFormStats.W) throw new IllegalStateException("이미 삭제대기 상태입니다.");
 
-        documentFormRepository.updateDocfoStat(docfoNo, stat);
+        // 삭제요청은 관리자만 가능
+        boolean isAdmin = requester.getAuthorities().stream().anyMatch(a ->
+                a.getAuthority().equals("ROLE_COM_ADMIN")
+                        || a.getAuthority().equals("ROLE_SEC_ADMIN")
+                        || a.getAuthority().equals("ROLE_THR_ADMIN")
+        );
+        if (!isAdmin) throw new AccessDeniedException("권한이 없습니다.");
 
-        if (stat == DocumentFormStats.R) {
-            if (rejectReason == null || rejectReason.isBlank()) {
-                throw new IllegalArgumentException("반려 사유는 필수입니다.");
-            }
-            documentFormRepository.updateRejectReason(docfoNo, rejectReason);
-        } else {
-            // 승인 시 반려 사유 제거
-            documentFormRepository.updateRejectReason(docfoNo, null);
-        }
+        // W로 바꿀 때 사유는 무조건 null
+        documentFormRepository.updateStatusAndReason(docfoNo, DocumentFormStats.W, null);
     }
 
-    //공통 함수
+    @Override
+    @Transactional
+    public void approveDelete(Long docfoNo, String comId) {
+        DocumentForm form = documentFormRepository.findById(docfoNo)
+                .orElseThrow(() -> new EntityNotFoundException("DocumentForm not found"));
+
+        validateCompany(form, comId);
+
+        if (form.getDocfoStat() != DocumentFormStats.W) {
+            throw new IllegalStateException("삭제대기(W) 상태에서만 삭제 승인할 수 있습니다.");
+        }
+
+        // D로 바꿀 때 사유는 무조건 null
+        documentFormRepository.updateStatusAndReason(docfoNo, DocumentFormStats.D, null);
+    }
+
+    @Override
+    @Transactional
+    public void rejectDelete(Long docfoNo, String comId, String rejectReason) {
+        DocumentForm form = documentFormRepository.findById(docfoNo)
+                .orElseThrow(() -> new EntityNotFoundException("DocumentForm not found"));
+
+        validateCompany(form, comId);
+
+        if (form.getDocfoStat() != DocumentFormStats.W) {
+            throw new IllegalStateException("삭제대기(W) 상태에서만 삭제 반려할 수 있습니다.");
+        }
+
+        // X는 사유 필수 + trim
+        String normalized = normalizeRejectReason(DocumentFormStats.X, rejectReason);
+
+        documentFormRepository.updateStatusAndReason(docfoNo, DocumentFormStats.X, normalized);
+    }
+    // 공통
     private String ensureJsonString(String raw) {
-        if (raw == null || raw.trim().isEmpty()) {
-            throw new IllegalArgumentException("cnttJson is empty");
-        }
-
+        if (raw == null || raw.trim().isEmpty()) throw new IllegalArgumentException("cnttJson is empty");
         String s = raw.trim();
-
-        if (s.startsWith("<")) {
-            throw new IllegalArgumentException("cnttJson must be JSON");
-        }
+        if (s.startsWith("<")) throw new IllegalArgumentException("cnttJson must be JSON");
 
         boolean isObj = s.startsWith("{") && s.endsWith("}");
         boolean isArr = s.startsWith("[") && s.endsWith("]");
-
-        if (!isObj && !isArr) {
-            throw new IllegalArgumentException("cnttJson must be JSON string");
-        }
+        if (!isObj && !isArr) throw new IllegalArgumentException("cnttJson must be JSON string");
 
         return s;
     }
@@ -248,5 +261,16 @@ public class DocumentFormServiceImpl implements DocumentFormService {
         if (!form.getCompany().getComId().equals(comId)) {
             throw new AccessDeniedException("권한이 없습니다.");
         }
+    }
+
+    // R/X면 사유 필수, 그 외는 무조건 null로 정규화
+    private String normalizeRejectReason(DocumentFormStats next, String reason) {
+        if (next == DocumentFormStats.R || next == DocumentFormStats.X) {
+            if (reason == null || reason.isBlank()) {
+                throw new IllegalArgumentException("반려 사유는 필수입니다.");
+            }
+            return reason.trim();
+        }
+        return null;
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/service/DocumentFormServiceImpl.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document_form/form/service/DocumentFormServiceImpl.java
@@ -41,18 +41,23 @@ public class DocumentFormServiceImpl implements DocumentFormService {
 
     @Override
     @Transactional(readOnly = true)
-    public Page<ResDocumentFormListDto> findListByStatus(
-            DocumentFormStats stat, String comId, String keyword, Pageable pageable
+    public Page<ResDocumentFormListDto> findListByStatuses(
+            List<DocumentFormStats> stats, String comId, String keyword, Pageable pageable
     ) {
+        // 비어있으면 기본값 A (안전장치)
+        List<DocumentFormStats> safeStats =
+                (stats == null || stats.isEmpty()) ? List.of(DocumentFormStats.A) : stats;
+
         boolean hasKeyword = (keyword != null && !keyword.isBlank());
+        String kw = hasKeyword ? keyword.trim() : null;
 
         Page<DocumentForm> page = hasKeyword
-                ? documentFormRepository
-                .findByDocfoStatAndCompany_ComIdAndDocfoNameContainingIgnoreCaseOrderByDocfoNoAsc(
-                        stat, comId, keyword.trim(), pageable
-                )
-                : documentFormRepository
-                .findByDocfoStatAndCompany_ComIdOrderByDocfoNoAsc(stat, comId, pageable);
+                ? documentFormRepository.findByDocfoStatInAndCompany_ComIdAndDocfoNameContainingIgnoreCaseOrderByDocfoNoAsc(
+                safeStats, comId, kw, pageable
+        )
+                : documentFormRepository.findByDocfoStatInAndCompany_ComIdOrderByDocfoNoAsc(
+                safeStats, comId, pageable
+        );
 
         return page.map(f -> new ResDocumentFormListDto(
                 f.getDocfoNo(),

--- a/src/main/resources/static/js/document-form/detail-form.js
+++ b/src/main/resources/static/js/document-form/detail-form.js
@@ -333,6 +333,8 @@ async function deleteForm(docfoNo) {
         bodyBox.className = 'tpl-bodyBox'
         elTemplateMount.appendChild(bodyBox)
 
+        console.log('ROLE=', ROLE, 'token?', !!localStorage.getItem('accessToken'))
+
         bootViewer(bodyBox, json)
 
         // ✅ Employee면 수정/삭제 비활성화 (UI만 막지 말고 서버 권한도 꼭 막아야 안전)

--- a/src/main/resources/static/js/document-form/list.js
+++ b/src/main/resources/static/js/document-form/list.js
@@ -6,8 +6,11 @@
     const API_BASE = '/api/v1/forms';
     const VIEW_BASE = '/form';
 
-    // "목록은 승인(A)만" 정책이면 true
+    // "목록은 승인(A)만(+ X 포함)" 정책이면 true
     const ONLY_APPROVED = true;
+
+    // ✅ 백엔드가 복수 상태(stat=A,X)를 지원하도록 바뀌었으니 여기서만 관리
+    const APPROVED_STATS = ['A', 'X']; // 필요 시 ['A','X','...']로 확장
 
     // 권한(쿠키 인증일 때는 JS가 JWT를 못 읽으므로, 서버가 붙여준 class로 판단)
     function isEmployee() {
@@ -77,7 +80,9 @@
     function openDetail(docfoNo) {
         if (docfoNo == null) return;
         const id = String(docfoNo);
-        window.open(`${VIEW_BASE}/${encodeURIComponent(id)}`, '_blank',
+        window.open(
+            `${VIEW_BASE}/${encodeURIComponent(id)}`,
+            '_blank',
             'width=1100,height=820,resizable=yes,scrollbars=yes'
         );
     }
@@ -124,22 +129,22 @@
         return { items: [], page: 0, size: Number(elSize?.value || 15), totalPages: 1, totalElements: 0 };
     }
 
-    function buildUrl() {
+    // ✅ 백엔드 복수 상태 지원(stat=A,X) 반영
+    function buildUrl(statsCsvOrNull) {
         const params = new URLSearchParams();
         params.set('page', String(page));
         params.set('size', String(Number(elSize?.value || 15)));
 
         const q = (elQ?.value || '').trim();
         if (q) {
-            // 백엔드가 뭐로 받든 최대한 맞춰주기
             params.set('q', q);
             params.set('docfoName', q);
             params.set('keyword', q);
         }
 
-        if (ONLY_APPROVED) {
-            params.set('stat', 'A');
-            params.set('docfoStat', 'A');
+        if (statsCsvOrNull) {
+            params.set('stat', statsCsvOrNull);       // 컨트롤러가 List로 받는 param
+            params.set('docfoStat', statsCsvOrNull);  // 혹시 다른 구현/레거시 대비
         }
 
         return `${API_BASE}?${params.toString()}`;
@@ -235,16 +240,16 @@
         elTbody.innerHTML = `<tr><td colspan="2" class="muted">로딩 중...</td></tr>`;
 
         try {
-            const url = buildUrl();
-            const res = await apiFetch(url, { method: 'GET' });
+            // ✅ ONLY_APPROVED=true면 A,X를 한 번에 조회(페이징/정렬/총개수 모두 서버 기준으로 정상)
+            const statsCsv = ONLY_APPROVED ? APPROVED_STATS.join(',') : null;
 
+            const res = await apiFetch(buildUrl(statsCsv), { method: 'GET' });
             if (!res.ok) {
                 const t = await res.text().catch(() => '');
                 throw new Error(`HTTP ${res.status} ${t}`);
             }
 
-            const json = await res.json();
-            const pg = normalizePage(json);
+            const pg = normalizePage(await res.json());
 
             totalPages = pg.totalPages ?? 1;
             totalElements = pg.totalElements ?? 0;
@@ -349,7 +354,9 @@
     btnCreate?.addEventListener('click', () => {
         if (isEmployee()) { toast('권한이 없습니다.'); return; }
 
-        window.open(`${VIEW_BASE}/new`, '_blank',
+        window.open(
+            `${VIEW_BASE}/new`,
+            '_blank',
             'width=1100,height=820,resizable=yes,scrollbars=yes'
         );
     });

--- a/src/main/resources/static/js/document-form/list.js
+++ b/src/main/resources/static/js/document-form/list.js
@@ -1,58 +1,30 @@
 (() => {
-    // =======================
     // ViewDocumentFormController 기준
     //  - 목록: /form/forms
     //  - 상세: /form/{docfoNo}
     //  - 생성: /form/new
-    //  - 수정: /form/{docfoNo}/edit (상세에서 이동)
-    // =======================
-    const API_BASE  = '/api/v1/forms';
+    const API_BASE = '/api/v1/forms';
     const VIEW_BASE = '/form';
 
     // "목록은 승인(A)만" 정책이면 true
     const ONLY_APPROVED = true;
 
-    // -----------------------
-    // ROLE (JWT payload) - 필요 시 생성/삭제 UI 제한
-    // -----------------------
-    function parseJwtPayload(token){
-        try{
-            const t = token.replace(/^Bearer\s+/i,'');
-            const base64 = t.split('.')[1];
-            if(!base64) return null;
-            const json = decodeURIComponent(atob(base64.replace(/-/g,'+').replace(/_/g,'/'))
-                .split('').map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2)).join(''));
-            return JSON.parse(json);
-        }catch(_){ return null; }
+    // 권한(쿠키 인증일 때는 JS가 JWT를 못 읽으므로, 서버가 붙여준 class로 판단)
+    function isEmployee() {
+        return document.documentElement.classList.contains('role-employee');
     }
-    function getUserRole(){
-        const token = (localStorage.getItem('accessToken') || '').trim();
-        const p = parseJwtPayload(token) || {};
-        const role =
-            p.role ||
-            p.auth ||
-            (Array.isArray(p.authorities) ? p.authorities[0] : null) ||
-            (Array.isArray(p.roles) ? p.roles[0] : null) ||
-            '';
-        return String(role).replace(/^ROLE_/,''); // ROLE_EMPLOYEE -> EMPLOYEE
-    }
-    const ROLE = getUserRole();
 
-    const elApiLabel = document.getElementById('apiLabel');
-    if (elApiLabel) elApiLabel.textContent = API_BASE;
+    const elTbody = document.getElementById('tbody');
+    const elInfo = document.getElementById('pageInfo');
+    const elPager = document.getElementById('pagerControls');
+    const elQ = document.getElementById('q');
+    const elSize = document.getElementById('size');
 
-    const elTbody   = document.getElementById('tbody');
-    const elInfo    = document.getElementById('pageInfo');
-    const elPager   = document.getElementById('pagerControls');
-
-    const elQ       = document.getElementById('q');
-    const elSize    = document.getElementById('size');
-
-    const elBulkDel  = document.getElementById('btnBulkDelete');
-    const elToast    = document.getElementById('toast');
-    const btnCreate  = document.getElementById('btnCreate');
+    const btnDeleteSelected = document.getElementById('btnDeleteSelected');
+    const btnCreate = document.getElementById('btnCreate');
     const btnRefresh = document.getElementById('btnRefresh');
-    const btnSearch  = document.getElementById('btnSearch');
+    const btnSearch = document.getElementById('btnSearch');
+    const elToast = document.getElementById('toast');
 
     const selected = new Set();
 
@@ -60,7 +32,7 @@
     let totalPages = 1;
     let totalElements = 0;
 
-    function toast(msg){
+    function toast(msg) {
         if (!elToast) return;
         elToast.textContent = msg;
         elToast.classList.add('show');
@@ -68,21 +40,21 @@
         toast._t = window.setTimeout(() => elToast.classList.remove('show'), 1400);
     }
 
-    function esc(s){
+    function esc(s) {
         return String(s ?? '')
-            .replaceAll('&','&amp;')
-            .replaceAll('<','&lt;')
-            .replaceAll('>','&gt;')
-            .replaceAll('"','&quot;')
-            .replaceAll("'",'&#39;');
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", '&#39;');
     }
 
-    function markFormListDirty(){
+    function markFormListDirty() {
         try { localStorage.setItem('list:dirty', 'true'); } catch (_) {}
     }
 
-    const _fetch = window.fetch.bind(window);
-
+    // 쿠키 인증이면 Authorization 헤더 없이도 동작해야 정상.
+    // (혹시 혼합구조라 localStorage accessToken도 쓰면 아래를 유지해도 됨)
     function getAccessToken() {
         return (localStorage.getItem('accessToken') || '').trim();
     }
@@ -98,10 +70,11 @@
         }
 
         if (token) headers.set('Authorization', /^Bearer\s+/i.test(token) ? token : `Bearer ${token}`);
-        return _fetch(url, { ...options, headers, credentials: 'same-origin' });
+
+        return fetch(url, { ...options, headers, credentials: 'same-origin' });
     }
 
-    function openDetail(docfoNo){
+    function openDetail(docfoNo) {
         if (docfoNo == null) return;
         const id = String(docfoNo);
         window.open(`${VIEW_BASE}/${encodeURIComponent(id)}`, '_blank',
@@ -109,25 +82,31 @@
         );
     }
 
-    function updateBulkDeleteUI(){
-        if (!elBulkDel) return;
-        if (selected.size > 0) {
-            elBulkDel.style.display = '';
-            elBulkDel.textContent = `선택 삭제 (${selected.size})`;
-        } else {
-            elBulkDel.style.display = 'none';
-            elBulkDel.textContent = '선택 삭제';
+    function updateBulkDeleteUI() {
+        if (!btnDeleteSelected) return;
+
+        if (isEmployee()) {
+            btnDeleteSelected.style.display = 'none';
+            btnDeleteSelected.disabled = true;
+            return;
         }
+
+        btnDeleteSelected.style.display = '';
+        const n = selected.size;
+
+        btnDeleteSelected.textContent = n > 0 ? `선택 삭제 (${n})` : '선택 삭제';
+        btnDeleteSelected.disabled = (n === 0);
+        btnDeleteSelected.title = (n === 0) ? '삭제할 항목을 선택하세요.' : '';
     }
 
-    function normalizePage(data){
+    function normalizePage(data) {
         if (data && Array.isArray(data.content)) {
             return {
                 items: data.content,
                 page: data.number ?? 0,
                 size: data.size ?? Number(elSize?.value || 15),
                 totalPages: data.totalPages ?? 1,
-                totalElements: data.totalElements ?? data.content.length
+                totalElements: data.totalElements ?? data.content.length,
             };
         }
         if (Array.isArray(data)) {
@@ -139,13 +118,13 @@
                 page: data.data.number ?? 0,
                 size: data.data.size ?? Number(elSize?.value || 15),
                 totalPages: data.data.totalPages ?? 1,
-                totalElements: data.data.totalElements ?? data.data.content.length
+                totalElements: data.data.totalElements ?? data.data.content.length,
             };
         }
         return { items: [], page: 0, size: Number(elSize?.value || 15), totalPages: 1, totalElements: 0 };
     }
 
-    function buildUrl(){
+    function buildUrl() {
         const params = new URLSearchParams();
         params.set('page', String(page));
         params.set('size', String(Number(elSize?.value || 15)));
@@ -158,7 +137,6 @@
             params.set('keyword', q);
         }
 
-        // ✅ "승인(A)만" 고정이면 안전하게 stat 관련 파라미터를 같이 보냄
         if (ONLY_APPROVED) {
             params.set('stat', 'A');
             params.set('docfoStat', 'A');
@@ -167,7 +145,7 @@
         return `${API_BASE}?${params.toString()}`;
     }
 
-    function render(rows){
+    function render(rows) {
         if (!elTbody) return;
 
         if (!rows || rows.length === 0) {
@@ -175,31 +153,34 @@
             return;
         }
 
-        const startNo = page * (Number(elSize?.value || 15));
+        const startNo = page * Number(elSize?.value || 15);
+        const employee = isEmployee();
 
         elTbody.innerHTML = rows.map((r, idx) => {
-            const docfoNo   = r.docfoNo ?? r.id ?? r.docfo_no;
+            const docfoNo = r.docfoNo ?? r.id ?? r.docfo_no;
             const docfoName = r.docfoName ?? r.name ?? r.docfo_name ?? '-';
 
             const idStr = String(docfoNo ?? '');
             const checked = selected.has(idStr) ? 'checked' : '';
             const rowNo = startNo + idx + 1;
 
-            const disableDeleteUi = (ROLE === 'EMPLOYEE');
+            // 1열: EMPLOYEE면 번호만 / 아니면 체크박스+번호
+            const firstCol = employee
+                ? `<span>${rowNo}</span>`
+                : `
+          <label class="selWrap">
+            <input type="checkbox"
+                   data-role="rowCheck"
+                   data-id="${esc(idStr)}"
+                   ${checked}/>
+            <span>${rowNo}</span>
+          </label>
+        `;
 
             return `
         <tr>
-          <td>
-            <label style="display:flex; gap:10px; align-items:center;">
-              <input type="checkbox"
-                     data-role="rowCheck"
-                     data-id="${esc(idStr)}"
-                     ${checked}
-                     ${disableDeleteUi ? 'disabled' : ''}/>
-              <span>${rowNo}</span>
-            </label>
-          </td>
-          <td>
+          <td class="col-select">${firstCol}</td>
+          <td class="col-title">
             <a class="titleLink" href="javascript:void(0)" onclick="window.openDetail('${esc(idStr)}')">
               ${esc(docfoName)}
             </a>
@@ -211,16 +192,16 @@
         updateBulkDeleteUI();
     }
 
-    function renderPager(){
+    function renderPager() {
         if (!elPager) return;
 
         const tp = Math.max(1, Number(totalPages) || 1);
-        const p  = Math.min(Math.max(0, Number(page) || 0), tp - 1);
+        const p = Math.min(Math.max(0, Number(page) || 0), tp - 1);
 
         if (tp <= 1) { elPager.innerHTML = ''; return; }
 
         let start = p - 2;
-        let end   = p + 2;
+        let end = p + 2;
 
         if (start < 0) { end += (0 - start); start = 0; }
         if (end > tp - 1) { start -= (end - (tp - 1)); end = tp - 1; }
@@ -230,14 +211,14 @@
         for (let i = start; i <= end; i++) nums.push(i);
 
         const disableFirstPrev = (p <= 0);
-        const disableNextLast  = (p >= tp - 1);
+        const disableNextLast = (p >= tp - 1);
 
-        const btn = (label, disabled, go, extra='') =>
+        const btn = (label, disabled, go, extra = '') =>
             `<button class="btn ${extra}" ${disabled ? 'disabled' : ''} data-go="${go}">${label}</button>`;
 
         const numBtn = (i) => {
             const active = i === p ? 'active' : '';
-            return `<button class="btn num ${active}" ${i===p?'disabled':''} data-page="${i}">${i+1}</button>`;
+            return `<button class="btn num ${active}" ${i === p ? 'disabled' : ''} data-page="${i}">${i + 1}</button>`;
         };
 
         elPager.innerHTML = [
@@ -245,20 +226,20 @@
             btn('&lsaquo;', disableFirstPrev, 'prev'),
             ...nums.map(numBtn),
             btn('&rsaquo;', disableNextLast, 'next'),
-            btn('&raquo;', disableNextLast, 'last')
+            btn('&raquo;', disableNextLast, 'last'),
         ].join('');
     }
 
-    async function load(){
+    async function load() {
         if (!elTbody) return;
         elTbody.innerHTML = `<tr><td colspan="2" class="muted">로딩 중...</td></tr>`;
 
-        try{
+        try {
             const url = buildUrl();
-            const res = await apiFetch(url, { method:'GET' });
+            const res = await apiFetch(url, { method: 'GET' });
 
-            if (!res.ok){
-                const t = await res.text().catch(()=> '');
+            if (!res.ok) {
+                const t = await res.text().catch(() => '');
                 throw new Error(`HTTP ${res.status} ${t}`);
             }
 
@@ -273,59 +254,55 @@
 
             renderPager();
             render(pg.items);
-
-        }catch(err){
+        } catch (err) {
             console.error(err);
             elTbody.innerHTML = `<tr><td colspan="2" class="muted">불러오기 실패: ${esc(err?.message || err)}</td></tr>`;
             renderPager();
         }
     }
 
-    // -------- checkbox select
+    // checkbox select
     elTbody?.addEventListener('change', (e) => {
         const cb = e.target;
-        if(!(cb instanceof HTMLInputElement)) return;
-        if(cb.dataset.role !== 'rowCheck') return;
+        if (!(cb instanceof HTMLInputElement)) return;
+        if (cb.dataset.role !== 'rowCheck') return;
 
         const id = cb.dataset.id;
-        if(!id) return;
+        if (!id) return;
 
-        if(cb.checked) selected.add(id);
+        if (cb.checked) selected.add(id);
         else selected.delete(id);
 
         updateBulkDeleteUI();
     });
 
-    // -------- pager click
+    // pager click
     elPager?.addEventListener('click', (e) => {
         const t = e.target;
-        if(!(t instanceof HTMLElement)) return;
+        if (!(t instanceof HTMLElement)) return;
 
         const pageAttr = t.getAttribute('data-page');
-        if(pageAttr != null){
+        if (pageAttr != null) {
             const nextPage = Number(pageAttr);
-            if(Number.isFinite(nextPage)){ page = nextPage; load(); }
+            if (Number.isFinite(nextPage)) { page = nextPage; load(); }
             return;
         }
 
         const go = t.getAttribute('data-go');
-        if(!go) return;
+        if (!go) return;
 
-        if(go === 'first') page = 0;
-        else if(go === 'prev') page = Math.max(0, page - 1);
-        else if(go === 'next') page = Math.min(totalPages - 1, page + 1);
-        else if(go === 'last') page = Math.max(0, totalPages - 1);
+        if (go === 'first') page = 0;
+        else if (go === 'prev') page = Math.max(0, page - 1);
+        else if (go === 'next') page = Math.min(totalPages - 1, page + 1);
+        else if (go === 'last') page = Math.max(0, totalPages - 1);
 
         load();
     });
 
-    // =======================
     // 삭제 처리:
     // 1) PATCH /api/v1/forms/{id}/status  body: { docfoStat:"D" }
     // 2) (fallback) DELETE /api/v1/forms/{id}
-    // =======================
-    async function softDelete(docfoNo){
-        // 1) PATCH status(D)
+    async function softDelete(docfoNo) {
         const patchRes = await apiFetch(`${API_BASE}/${encodeURIComponent(docfoNo)}/status`, {
             method: 'PATCH',
             body: JSON.stringify({ docfoStat: 'D' }),
@@ -333,53 +310,45 @@
 
         if (patchRes.ok) return true;
 
-        // 405/404 등일 수 있으니 fallback
         const delRes = await apiFetch(`${API_BASE}/${encodeURIComponent(docfoNo)}`, { method: 'DELETE' });
         if (!delRes.ok) {
-            const t = await delRes.text().catch(()=> '');
+            const t = await delRes.text().catch(() => '');
             throw new Error(`삭제 실패(docfoNo=${docfoNo}) HTTP ${delRes.status} ${t}`);
         }
         return true;
     }
 
-    // -------- bulk delete (Employee면 막기)
-    elBulkDel?.addEventListener('click', async () => {
-        if (ROLE === 'EMPLOYEE') {
-            toast('권한이 없습니다.');
-            return;
-        }
-        if(selected.size === 0) return;
+    // bulk delete
+    btnDeleteSelected?.addEventListener('click', async () => {
+        if (isEmployee()) { toast('권한이 없습니다.'); return; }
+        if (selected.size === 0) return;
 
         const ids = Array.from(selected);
-        if(!confirm(`선택한 ${ids.length}개를 삭제 처리할까요? (stat=D)`)) return;
+        if (!confirm(`선택한 ${ids.length}개를 삭제 처리할까요? (stat=D)`)) return;
 
-        try{
-            elBulkDel.disabled = true;
+        try {
+            btnDeleteSelected.disabled = true;
 
-            for(const docfoNo of ids){
+            for (const docfoNo of ids) {
                 await softDelete(docfoNo);
             }
 
             toast('선택 삭제 완료');
             selected.clear();
-            updateBulkDeleteUI();
             markFormListDirty();
             await load();
-
-        }catch(err){
+        } catch (err) {
             console.error(err);
             alert('선택 삭제 실패: ' + (err?.message || err));
-        }finally{
-            elBulkDel.disabled = false;
+        } finally {
+            updateBulkDeleteUI();
         }
     });
 
-    // -------- create (Employee면 비활성화)
+    // create
     btnCreate?.addEventListener('click', () => {
-        if (ROLE === 'EMPLOYEE') {
-            toast('권한이 없습니다.');
-            return;
-        }
+        if (isEmployee()) { toast('권한이 없습니다.'); return; }
+
         window.open(`${VIEW_BASE}/new`, '_blank',
             'width=1100,height=820,resizable=yes,scrollbars=yes'
         );
@@ -387,12 +356,12 @@
 
     btnRefresh?.addEventListener('click', () => load());
     btnSearch?.addEventListener('click', () => { page = 0; load(); });
-    elQ?.addEventListener('keydown', (e) => { if(e.key === 'Enter'){ page = 0; load(); } });
+    elQ?.addEventListener('keydown', (e) => { if (e.key === 'Enter') { page = 0; load(); } });
     elSize?.addEventListener('change', () => { page = 0; load(); });
 
     window.openDetail = openDetail;
 
-    // -------- storage listener (list:dirty)
+    // storage listener (list:dirty)
     window.addEventListener('storage', (e) => {
         if (e.key === 'list:dirty' && e.newValue === 'true') {
             try { localStorage.removeItem('list:dirty'); } catch (_) {}
@@ -400,11 +369,8 @@
         }
     });
 
-    // -------- 초기 권한 기반 UI 처리
-    if (ROLE === 'EMPLOYEE') {
-        if (btnCreate) btnCreate.disabled = true;
-        if (elBulkDel) elBulkDel.style.display = 'none';
-    }
-
+    // init
+    if (isEmployee() && btnCreate) btnCreate.disabled = true;
+    updateBulkDeleteUI();
     load();
 })();

--- a/src/main/resources/static/js/document-form/pending-list.js
+++ b/src/main/resources/static/js/document-form/pending-list.js
@@ -1,24 +1,30 @@
 (() => {
-    const API_BASE  = '/api/v1/forms';
-    // ✅ ViewDocumentFormController 기준: 상세 /form/{docfoNo}
+    const API_BASE = '/api/v1/forms';
+    // ViewDocumentFormController 기준: 상세 /form/{docfoNo}
     const VIEW_BASE = '/form';
 
     const elApiLabel = document.getElementById('apiLabel');
     if (elApiLabel) elApiLabel.textContent = API_BASE;
 
     const elTbody = document.getElementById('tbody');
-    const elInfo  = document.getElementById('pageInfo');
+    const elInfo = document.getElementById('pageInfo');
     const elPager = document.getElementById('pagerControls');
 
-    const elSize  = document.getElementById('size');
-    const elMode  = document.getElementById('statMode');
+    const elSize = document.getElementById('size');
+    const elMode = document.getElementById('statMode'); // ALL / P / R (드롭다운 라벨: 전체/대기/반려)
     const elToast = document.getElementById('toast');
 
     let page = 0;
     let totalPages = 1;
     let totalElements = 0;
 
-    function toast(msg){
+    // Role 판단: JWT 파싱 ❌
+    // Thymeleaf에서 <html class="role-thr-admin"> 같은 방식으로 주입했다고 가정
+    function isThrAdmin() {
+        return document.documentElement.classList.contains('role-thr-admin');
+    }
+
+    function toast(msg) {
         if (!elToast) return;
         elToast.textContent = msg;
         elToast.classList.add('show');
@@ -26,39 +32,44 @@
         toast._t = window.setTimeout(() => elToast.classList.remove('show'), 1400);
     }
 
-    function esc(s){
+    function esc(s) {
         return String(s ?? '')
-            .replaceAll('&','&amp;')
-            .replaceAll('<','&lt;')
-            .replaceAll('>','&gt;')
-            .replaceAll('"','&quot;')
-            .replaceAll("'",'&#39;');
+            .replaceAll('&', '&amp;')
+            .replaceAll('<', '&lt;')
+            .replaceAll('>', '&gt;')
+            .replaceAll('"', '&quot;')
+            .replaceAll("'", "&#39;");
     }
 
-    function markFormListDirty(){
-        try { localStorage.setItem('list:dirty', 'true'); } catch (_) {}
+    function markFormListDirty() {
+        try {
+            localStorage.setItem('list:dirty', 'true');
+        } catch (_) {
+        }
     }
 
     const _fetch = window.fetch.bind(window);
 
-    function getAccessToken() {
-        return (localStorage.getItem('accessToken') || '').trim();
-    }
-
+    // 쿠키 기반 인증 (HttpOnly)
+    // - Authorization 헤더로 토큰 넣지 않음
+    // - credentials: 'same-origin' 으로 쿠키 자동 전송
     async function apiFetch(url, options = {}) {
-        const token = getAccessToken();
         const headers = new Headers(options.headers || {});
         if (!headers.has('Accept')) headers.set('Accept', 'application/json');
-        if (options.body && !headers.has('Content-Type')) headers.set('Content-Type', 'application/json');
 
-        if (token) {
-            const hasBearer = /^Bearer\s+/i.test(token);
-            headers.set('Authorization', hasBearer ? token : `Bearer ${token}`);
+        const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData;
+        if (options.body && !isFormData && !headers.has('Content-Type')) {
+            headers.set('Content-Type', 'application/json');
         }
-        return _fetch(url, { ...options, headers });
+
+        return _fetch(url, {
+            ...options,
+            headers,
+            credentials: 'same-origin',
+        });
     }
 
-    function openDetail(docfoNo){
+    function openDetail(docfoNo) {
         if (docfoNo == null) return;
         const id = String(docfoNo);
         window.open(`${VIEW_BASE}/${encodeURIComponent(id)}`, '_blank',
@@ -66,7 +77,7 @@
         );
     }
 
-    function normalizePage(data){
+    function normalizePage(data) {
         if (data && Array.isArray(data.content)) {
             return {
                 items: data.content,
@@ -76,10 +87,10 @@
                 totalElements: data.totalElements ?? data.content.length
             };
         }
-        return { items: [], page: 0, size: Number(elSize?.value || 15), totalPages: 1, totalElements: 0 };
+        return {items: [], page: 0, size: Number(elSize?.value || 15), totalPages: 1, totalElements: 0};
     }
 
-    function buildUrl(stat, pageNo, sizeNo){
+    function buildUrl(stat, pageNo, sizeNo) {
         const params = new URLSearchParams();
         params.set('page', String(pageNo));
         params.set('size', String(sizeNo));
@@ -87,13 +98,13 @@
         return `${API_BASE}?${params.toString()}`;
     }
 
-    function getWriterName(writer){
+    function getWriterName(writer) {
         if (!writer) return '-';
         if (typeof writer === 'string') return writer;
         return writer.empName ?? writer.name ?? writer.username ?? writer.empNm ?? writer.emp_id ?? writer.empId ?? '-';
     }
 
-    function getRejectReason(r){
+    function getRejectReason(r) {
         return r?.rejectReason
             ?? r?.rejReason
             ?? r?.reject_reason
@@ -104,47 +115,98 @@
             ?? null;
     }
 
-    function getStatPill(stat){
+    // 상태 라벨: 코드 제거 + W/X 추가
+    function getStatPill(stat) {
         const s = String(stat ?? '').trim() || '-';
-        const cls = (s === 'P' || s === 'R' || s === 'A') ? s : '';
-        const label = (s === 'P') ? '대기(P)' : (s === 'R') ? '반려(R)' : (s === 'A') ? '승인(A)' : s;
-        return `<span class="statPill ${cls}">${esc(label)}</span>`;
+
+        const map = {
+            P: {cls: 'P', label: '대기'},
+            R: {cls: 'R', label: '반려'},
+            A: {cls: 'A', label: '승인'},
+            W: {cls: 'W', label: '삭제대기'},
+            X: {cls: 'X', label: '삭제반려'},
+            D: {cls: 'D', label: '삭제'},
+            T: {cls: 'T', label: '임시저장'},
+        };
+
+        const it = map[s] || {cls: '', label: s};
+        return `<span class="statPill ${esc(it.cls)}">${esc(it.label)}</span>`;
     }
 
-    async function showRejectReason(docfoNo){
-        try{
-            const res = await apiFetch(`${API_BASE}/${encodeURIComponent(docfoNo)}`, { method:'GET' });
-            if(!res.ok) throw new Error(`HTTP ${res.status}`);
+    async function showRejectReason(docfoNo) {
+        try {
+            const res = await apiFetch(`${API_BASE}/${encodeURIComponent(docfoNo)}`, {method: 'GET'});
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
             const data = await res.json();
-            const reason = getRejectReason(data) ?? '반려 사유가 저장되어 있지 않아요.';
-            alert(`반려 사유:\n${reason}`);
-        }catch(e){
-            alert('반려사유 조회 실패: ' + (e?.message || e));
+            const reason = getRejectReason(data) ?? '사유가 저장되어 있지 않아요.';
+            alert(`사유:\n${reason}`);
+        } catch (e) {
+            alert('사유 조회 실패: ' + (e?.message || e));
         }
     }
 
-    function render(rows){
-        if(!rows || rows.length === 0){
+    // mode에 맞춰 상태 묶음 반환
+    function getStatsByMode(mode) {
+        if (mode === 'P') return ['P', 'W'];
+        if (mode === 'R') return ['R', 'X'];
+        return ['P', 'W', 'R', 'X'];
+    }
+
+    function hasNonBlank(v) {
+        return v != null && String(v).trim() !== '';
+    }
+
+    function render(rows) {
+        if (!elTbody) return;
+
+        if (!rows || rows.length === 0) {
             elTbody.innerHTML = `<tr><td colspan="5" class="muted">조회 결과가 없어요.</td></tr>`;
             return;
         }
 
-        const startNo = page * (Number(elSize?.value || 15));
+        const startNo = page * Number(elSize?.value || 15);
+        const thr = isThrAdmin();
 
         elTbody.innerHTML = rows.map((r, idx) => {
-            const docfoNo   = r.docfoNo ?? r.id ?? r.docfo_no;
+            const docfoNo = r.docfoNo ?? r.id ?? r.docfo_no;
             const docfoName = r.docfoName ?? r.name ?? r.docfo_name ?? '-';
-            const stat      = r.docfoStat ?? r.docfo_stat ?? '-';
+            const stat = r.docfoStat ?? r.docfo_stat ?? '-';
 
-            const writerObj  = r.writer ?? r.employee ?? r.writerInfo ?? null;
+            const writerObj = r.writer ?? r.employee ?? r.writerInfo ?? null;
             const writerName = getWriterName(writerObj);
 
             const idStr = String(docfoNo ?? '');
             const rowNo = startNo + idx + 1;
 
-            const isRejected = (stat === 'R');
-            const canApprove = (stat === 'P'); // ✅ 대기만 승인 가능
-            const canReject  = (stat === 'P'); // ✅ 대기만 반려 가능
+            const reasonInline = getRejectReason(r);
+            const isRejectedGroup = (stat === 'R' || stat === 'X');
+
+            // 처리 버튼 정책
+            let actionHtml = '';
+
+            if (thr) {
+                actionHtml = hasNonBlank(reasonInline)
+                    ? `<button class="btn sm warn" onclick="window.showRejectReason('${esc(idStr)}')">사유</button>`
+                    : `<span class="muted">-</span>`;
+            } else {
+                if (stat === 'P') {
+                    actionHtml = `
+                        <button class="btn sm ok" onclick="window.approveOne('${esc(idStr)}')">승인</button>
+                        <button class="btn sm danger" onclick="window.rejectOne('${esc(idStr)}')">반려</button>
+                    `;
+                } else if (stat === 'W') {
+                    actionHtml = `
+                        <button class="btn sm ok" onclick="window.approveDeleteOne('${esc(idStr)}')">삭제승인</button>
+                        <button class="btn sm danger" onclick="window.rejectDeleteOne('${esc(idStr)}')">삭제반려</button>
+                    `;
+                } else if (isRejectedGroup) {
+                    actionHtml = hasNonBlank(reasonInline)
+                        ? `<button class="btn sm warn" onclick="window.showRejectReason('${esc(idStr)}')">사유</button>`
+                        : `<span class="muted">-</span>`;
+                } else {
+                    actionHtml = `<span class="muted">-</span>`;
+                }
+            }
 
             return `
         <tr>
@@ -158,14 +220,7 @@
           <td>${getStatPill(stat)}</td>
           <td style="text-align:right;">
             <div class="row-actions">
-              ${
-                isRejected
-                    ? `<button class="btn sm warn" onclick="window.showRejectReason('${esc(idStr)}')">반려사유</button>`
-                    : `
-                    <button class="btn sm ok" ${canApprove ? '' : 'disabled'} onclick="window.approveOne('${esc(idStr)}')">승인</button>
-                    <button class="btn sm danger" ${canReject ? '' : 'disabled'} onclick="window.rejectOne('${esc(idStr)}')">반려</button>
-                  `
-            }
+              ${actionHtml}
             </div>
           </td>
         </tr>
@@ -173,42 +228,42 @@
         }).join('');
     }
 
-    function renderPager(){
-        if(!elPager) return;
+    function renderPager() {
+        if (!elPager) return;
 
         const tp = Math.max(1, Number(totalPages) || 1);
-        const p  = Math.min(Math.max(0, Number(page) || 0), tp - 1);
+        const p = Math.min(Math.max(0, Number(page) || 0), tp - 1);
 
-        if(tp <= 1){
+        if (tp <= 1) {
             elPager.innerHTML = '';
             return;
         }
 
         let start = p - 2;
-        let end   = p + 2;
+        let end = p + 2;
 
-        if(start < 0){
+        if (start < 0) {
             end += (0 - start);
             start = 0;
         }
-        if(end > tp - 1){
+        if (end > tp - 1) {
             start -= (end - (tp - 1));
             end = tp - 1;
         }
         start = Math.max(0, start);
 
         const nums = [];
-        for(let i = start; i <= end; i++) nums.push(i);
+        for (let i = start; i <= end; i++) nums.push(i);
 
         const disableFirstPrev = (p <= 0);
-        const disableNextLast  = (p >= tp - 1);
+        const disableNextLast = (p >= tp - 1);
 
-        const btn = (label, disabled, go, extra='') =>
+        const btn = (label, disabled, go, extra = '') =>
             `<button class="btn ${extra}" ${disabled ? 'disabled' : ''} data-go="${go}">${label}</button>`;
 
         const numBtn = (i) => {
             const active = i === p ? 'active' : '';
-            return `<button class="btn num ${active}" ${i===p?'disabled':''} data-page="${i}">${i+1}</button>`;
+            return `<button class="btn num ${active}" ${i === p ? 'disabled' : ''} data-page="${i}">${i + 1}</button>`;
         };
 
         elPager.innerHTML = [
@@ -220,54 +275,37 @@
         ].join('');
     }
 
-    async function load(){
+    async function load() {
+        if (!elTbody) return;
         elTbody.innerHTML = `<tr><td colspan="5" class="muted">로딩 중...</td></tr>`;
 
-        try{
+        try {
             const sizeNo = Number(elSize?.value || 15);
-            const mode = elMode?.value || 'PR'; // P / R / PR
+            const mode = elMode?.value || 'ALL'; // ALL / P / R
 
-            if(mode === 'P' || mode === 'R'){
-                const url = buildUrl(mode, page, sizeNo);
-                const res = await apiFetch(url, { method:'GET' });
-                if(!res.ok){
-                    const t = await res.text().catch(()=> '');
-                    throw new Error(`HTTP ${res.status} ${t}`);
-                }
-                const json = await res.json();
-                const pg = normalizePage(json);
-
-                totalPages = pg.totalPages ?? 1;
-                totalElements = pg.totalElements ?? 0;
-                page = pg.page ?? page;
-
-                if (elInfo) elInfo.textContent = `page ${page + 1} / ${totalPages}  ·  total ${totalElements}`;
-                renderPager();
-                render(pg.items);
-                return;
-            }
-
-            // PR: P와 R을 합쳐서 클라 페이징 (BIG 한번씩)
+            // 항상 "묶음"을 BIG로 가져와서 클라 페이징
             const BIG = 1000;
-            const [pRes, rRes] = await Promise.all([
-                apiFetch(buildUrl('P', 0, BIG), { method:'GET' }),
-                apiFetch(buildUrl('R', 0, BIG), { method:'GET' }),
-            ]);
+            const stats = getStatsByMode(mode);
 
-            if(!pRes.ok) throw new Error(`P 조회 실패 HTTP ${pRes.status} ${(await pRes.text().catch(()=>''))}`);
-            if(!rRes.ok) throw new Error(`R 조회 실패 HTTP ${rRes.status} ${(await rRes.text().catch(()=>''))}`);
+            const results = await Promise.all(
+                stats.map(s => apiFetch(buildUrl(s, 0, BIG), {method: 'GET'}).then(async (res) => {
+                    if (!res.ok) {
+                        const t = await res.text().catch(() => '');
+                        throw new Error(`${s} 조회 실패 HTTP ${res.status} ${t}`);
+                    }
+                    return normalizePage(await res.json()).items;
+                }))
+            );
 
-            const pJson = normalizePage(await pRes.json());
-            const rJson = normalizePage(await rRes.json());
-
+            // 합치고 docfoNo 기준 중복 제거 + 정렬
             const mergedMap = new Map();
-            [...pJson.items, ...rJson.items].forEach(it => {
+            results.flat().forEach(it => {
                 const key = String(it.docfoNo ?? it.id ?? it.docfo_no ?? '');
-                if(!key) return;
+                if (!key) return;
                 mergedMap.set(key, it);
             });
 
-            const merged = Array.from(mergedMap.values()).sort((a,b) => {
+            const merged = Array.from(mergedMap.values()).sort((a, b) => {
                 const ax = Number(a.docfoNo ?? a.id ?? a.docfo_no ?? 0);
                 const bx = Number(b.docfoNo ?? b.id ?? b.docfo_no ?? 0);
                 return ax - bx;
@@ -284,21 +322,16 @@
             renderPager();
             render(rows);
 
-        }catch(err){
+        } catch (err) {
             console.error(err);
             elTbody.innerHTML = `<tr><td colspan="5" class="muted">불러오기 실패: ${esc(err?.message || err)}</td></tr>`;
             renderPager();
         }
     }
 
-    // =======================
-    // 승인/반려 처리
-    // PATCH /api/v1/forms/{docfoNo}/status
-    // body: { "docfoStat":"A" } or { "docfoStat":"R", "rejectReason":"..." }
-    // =======================
-
-    async function updateStatus(docfoNo, docfoStat, rejectReason){
-        const payload = { docfoStat };
+    // 승인/반려 처리 (P만 가능)
+    async function updateStatus(docfoNo, docfoStat, rejectReason) {
+        const payload = {docfoStat};
         if (rejectReason != null && String(rejectReason).trim() !== '') {
             payload.rejectReason = String(rejectReason).trim();
         }
@@ -308,44 +341,97 @@
             body: JSON.stringify(payload),
         });
 
-        if(!res.ok){
-            const t = await res.text().catch(()=> '');
+        if (!res.ok) {
+            const t = await res.text().catch(() => '');
             throw new Error(`상태 변경 실패(docfoNo=${docfoNo}) HTTP ${res.status} ${t}`);
         }
         return true;
     }
 
-    async function approveOne(docfoNo){
-        if(!docfoNo) return;
-        try{
+    async function approveOne(docfoNo) {
+        if (!docfoNo) return;
+        try {
             await updateStatus(docfoNo, 'A');
             toast('승인 처리 완료');
             markFormListDirty();
             await load();
-        }catch(err){
+        } catch (err) {
             console.error(err);
             alert('승인 실패: ' + (err?.message || err));
         }
     }
 
-    async function rejectOne(docfoNo){
-        if(!docfoNo) return;
+    async function rejectOne(docfoNo) {
+        if (!docfoNo) return;
 
         const reason = prompt('반려 사유(필수):', '');
-        if(reason === null) return; // 취소
-        if(String(reason).trim() === ''){
+        if (reason === null) return; // 취소
+        if (String(reason).trim() === '') {
             alert('반려 사유를 입력해주세요.');
             return;
         }
 
-        try{
+        try {
             await updateStatus(docfoNo, 'R', reason);
             toast('반려 처리 완료');
             markFormListDirty();
             await load();
-        }catch(err){
+        } catch (err) {
             console.error(err);
             alert('반려 실패: ' + (err?.message || err));
+        }
+    }
+
+    async function approveDeleteOne(docfoNo) {
+        if (!docfoNo) return;
+        if (!confirm('삭제 요청을 승인하시겠습니까?')) return;
+
+        try {
+            const res = await apiFetch(`${API_BASE}/${encodeURIComponent(docfoNo)}/delete-approve`, {
+                method: 'PATCH',
+            });
+
+            if (!res.ok) {
+                const t = await res.text().catch(() => '');
+                throw new Error(`삭제 승인 실패 HTTP ${res.status} ${t}`);
+            }
+
+            toast('삭제 승인 완료');
+            markFormListDirty();
+            await load();
+        } catch (err) {
+            console.error(err);
+            alert('삭제 승인 실패: ' + (err?.message || err));
+        }
+    }
+
+    async function rejectDeleteOne(docfoNo) {
+        if (!docfoNo) return;
+
+        const reason = prompt('삭제 반려 사유(필수):', '');
+        if (reason === null) return;
+        if (String(reason).trim() === '') {
+            alert('삭제 반려 사유를 입력해주세요.');
+            return;
+        }
+
+        try {
+            const res = await apiFetch(`${API_BASE}/${encodeURIComponent(docfoNo)}/delete-reject`, {
+                method: 'PATCH',
+                body: JSON.stringify({ rejectReason: String(reason).trim() }),
+            });
+
+            if (!res.ok) {
+                const t = await res.text().catch(() => '');
+                throw new Error(`삭제 반려 실패 HTTP ${res.status} ${t}`);
+            }
+
+            toast('삭제 반려 완료');
+            markFormListDirty();
+            await load();
+        } catch (err) {
+            console.error(err);
+            alert('삭제 반려 실패: ' + (err?.message || err));
         }
     }
 
@@ -354,16 +440,18 @@
     window.showRejectReason = showRejectReason;
     window.approveOne = approveOne;
     window.rejectOne = rejectOne;
+    window.approveDeleteOne = approveDeleteOne;
+    window.rejectDeleteOne = rejectDeleteOne;
 
     // pager click
     elPager?.addEventListener('click', (e) => {
         const t = e.target;
-        if(!(t instanceof HTMLElement)) return;
+        if (!(t instanceof HTMLElement)) return;
 
         const pageAttr = t.getAttribute('data-page');
-        if(pageAttr != null){
+        if (pageAttr != null) {
             const nextPage = Number(pageAttr);
-            if(Number.isFinite(nextPage)){
+            if (Number.isFinite(nextPage)) {
                 page = nextPage;
                 load();
             }
@@ -371,40 +459,46 @@
         }
 
         const go = t.getAttribute('data-go');
-        if(!go) return;
+        if (!go) return;
 
-        if(go === 'first') page = 0;
-        else if(go === 'prev') page = Math.max(0, page - 1);
-        else if(go === 'next') page = Math.min(totalPages - 1, page + 1);
-        else if(go === 'last') page = Math.max(0, totalPages - 1);
+        if (go === 'first') page = 0;
+        else if (go === 'prev') page = Math.max(0, page - 1);
+        else if (go === 'next') page = Math.min(totalPages - 1, page + 1);
+        else if (go === 'last') page = Math.max(0, totalPages - 1);
 
         load();
     });
 
     // controls
     document.getElementById('btnRefresh')?.addEventListener('click', () => load());
-    elSize?.addEventListener('change', () => { page = 0; load(); });
-    elMode?.addEventListener('change', () => { page = 0; load(); });
+    elSize?.addEventListener('change', () => {
+        page = 0;
+        load();
+    });
+    elMode?.addEventListener('change', () => {
+        page = 0;
+        load();
+    });
 
     // storage listener
     window.addEventListener('storage', (e) => {
-        if(e.key === 'list:dirty' && e.newValue === 'true'){
+        if (e.key === 'list:dirty' && e.newValue === 'true') {
             consumeDirtyAndReload();
         }
     });
 
-    function consumeDirtyAndReload(){
-        try{
+    function consumeDirtyAndReload() {
+        try {
             const v = localStorage.getItem('list:dirty');
             if (v === 'true') {
                 localStorage.removeItem('list:dirty');
                 load();
             }
-        }catch(_){}
+        } catch (_) {
+        }
     }
 
     window.addEventListener('focus', consumeDirtyAndReload);
-
     document.addEventListener('visibilitychange', () => {
         if (!document.hidden) consumeDirtyAndReload();
     });

--- a/src/main/resources/templates/document-form/detail.html
+++ b/src/main/resources/templates/document-form/detail.html
@@ -10,12 +10,9 @@
     <link rel="stylesheet" href="/css/editor-preset-header.css" />
 
     <style>
-        /* =========================
-   Header Layout
-========================= */
-        .tpl-header { max-width: 980px; margin: 0 auto 18px; }
+        .tpl-header{max-width:980px;margin:0 auto 18px}
 
-        .tpl-titleLine{ display:flex; justify-content:center; margin: 6px 0 18px; }
+        .tpl-titleLine{display:flex;justify-content:center;margin:6px 0 18px}
         .tpl-title{
             margin:0;
             font-size:36px;
@@ -25,68 +22,48 @@
             white-space:nowrap;
         }
 
-        /* =========================
-           Preset Header Tables (좌/우)
-        ========================= */
         .tpl-presetHeader{
-            max-width: 980px;
-            margin: 0 auto 18px;
-            display: grid;
-            grid-template-columns: 1fr 1.6fr;
-            gap: 28px;
-            align-items: flex-start;
+            max-width:980px;
+            margin:0 auto 18px;
+            display:grid;
+            grid-template-columns:1fr 1.6fr;
+            gap:28px;
+            align-items:flex-start;
         }
+        .tpl-presetRight{justify-self:end}
 
-        /* 오른쪽 표를 페이지 우측으로 */
-        .tpl-presetRight{ justify-self: end; }
-
-        /* 테이블 공통 테두리 */
         .tpl-presetHeader table{
-            width: 100%;
-            border-collapse: collapse;
-            border: 1px solid #d7dbe3;
+            width:100%;
+            border-collapse:collapse;
+            border:1px solid #d7dbe3;
         }
-
         .tpl-presetHeader td,
         .tpl-presetHeader th{
-            border: 1px solid #d7dbe3;
-            padding: 8px 10px;
-            vertical-align: top;
+            border:1px solid #d7dbe3;
+            padding:8px 10px;
+            vertical-align:top;
         }
 
-        /* 왼쪽 표: 2번째 열 넓히기 */
-        .tpl-presetLeft td:first-child{
-            width: 30%;
-            white-space: nowrap;
-        }
-        .tpl-presetLeft td:last-child{
-            width: 70%;
-        }
+        .tpl-presetLeft td:first-child{width:30%;white-space:nowrap}
+        .tpl-presetLeft td:last-child{width:70%}
 
-        /* 오른쪽 표: 헤더 무게감 + 서명행 높이 */
         .tpl-presetRight tr:first-child th{
             background:#f4f6fb;
             font-weight:600;
-            padding: 10px 8px;
+            padding:10px 8px;
             text-align:center;
         }
-
         .tpl-presetRight tr:nth-child(2) th,
         .tpl-presetRight tr:nth-child(2) td{
-            height: 100px;
-            vertical-align: middle;
+            height:100px;
+            vertical-align:middle;
         }
-
-        /* 오른쪽 표 '서명' 셀도 헤더처럼 보이게 */
         .tpl-presetRight tr:nth-child(2) th{
             background:#f4f6fb;
             font-weight:600;
             text-align:center;
         }
 
-        /* =========================
-           Categories Box
-        ========================= */
         .tpl-catsBox{
             margin-top:12px;
             border:1px solid #e6e6e6;
@@ -94,7 +71,6 @@
             background:#fff;
             padding:10px 12px;
         }
-
         .tpl-cats{
             display:flex;
             gap:12px;
@@ -102,8 +78,7 @@
             align-items:center;
         }
 
-        /* 카테고리 라디오 비활성(상세에서 클릭 방지) */
-        .tpl-catRadio{ pointer-events: none; }
+        .tpl-catRadio{pointer-events:none}
 
         .tpl-catItem{
             display:inline-flex;
@@ -111,8 +86,7 @@
             gap:8px;
             padding:4px 2px;
         }
-
-        .tpl-catItem input[type="radio"]{ transform: translateY(1px); }
+        .tpl-catItem input[type="radio"]{transform:translateY(1px)}
 
         .tpl-pill{
             border:0;
@@ -122,86 +96,65 @@
             font-size:13px;
         }
 
-        .tpl-muted{ color:#777; font-size:13px; }
+        .tpl-muted{color:#777;font-size:13px;font-weight:700}
 
-        /* (선택) 카테고리 라벨 느낌: "카테고리 없음" 같은 텍스트가 더 안정적으로 보이게 */
-        .tpl-cats .tpl-muted{
-            font-weight: 700;
-        }
-
-        /* =========================
-           Body (JSON content)
-        ========================= */
-        #templateMount{ max-width:980px; margin:0 auto; }
-
+        #templateMount{max-width:980px;margin:0 auto}
         #templateMount .tpl-bodyBox{
             background:#fff;
             border:1px solid #e1e3ea;
             border-radius:14px;
             padding:24px 28px;
             overflow-x:auto;
-            font-family: inherit;
+            font-family:inherit;
         }
 
-        /* 본문 정렬 데이터 속성 */
-        #templateMount .tpl-bodyBox [data-ta="left"]   { text-align:left !important; }
-        #templateMount .tpl-bodyBox [data-ta="center"] { text-align:center !important; }
-        #templateMount .tpl-bodyBox [data-ta="right"]  { text-align:right !important; }
-        #templateMount .tpl-bodyBox [data-ta="justify"]{ text-align:justify !important; }
+        #templateMount .tpl-bodyBox [data-ta="left"]{text-align:left !important}
+        #templateMount .tpl-bodyBox [data-ta="center"]{text-align:center !important}
+        #templateMount .tpl-bodyBox [data-ta="right"]{text-align:right !important}
 
-        /* 본문 기본 간격 */
         .tpl-bodyBox p,
         .tpl-bodyBox h1,
         .tpl-bodyBox h2,
-        .tpl-bodyBox h3{ margin: 8px 0; }
+        .tpl-bodyBox h3{margin:8px 0}
 
-        /* 본문 헤딩 크기 다운(메인 제목과 경쟁 방지) */
-        .tpl-bodyBox h1{ font-size: 28px; line-height: 1.25; }
-        .tpl-bodyBox h2{ font-size: 22px; line-height: 1.28; }
-        .tpl-bodyBox h3{ font-size: 18px; line-height: 1.3; }
+        .tpl-bodyBox h1{font-size:28px;line-height:1.25}
+        .tpl-bodyBox h2{font-size:22px;line-height:1.28}
+        .tpl-bodyBox h3{font-size:18px;line-height:1.3}
 
-        /* 본문 테이블(내용 테이블) */
         .tpl-bodyBox table{
-            border-collapse: collapse;
-            width: 100%;
-            table-layout: fixed;
-            border: 1px solid #d7dbe3;
+            border-collapse:collapse;
+            width:100%;
+            table-layout:fixed;
+            border:1px solid #d7dbe3;
         }
-
         .tpl-bodyBox td,
         .tpl-bodyBox th{
-            border: 1px solid #d7dbe3;
-            padding: 8px 10px;
-            vertical-align: top;
+            border:1px solid #d7dbe3;
+            padding:8px 10px;
+            vertical-align:top;
         }
-
         .tpl-bodyBox th{
             background:#f4f6fb;
             font-weight:700;
             text-align:center;
         }
 
-        /* 입력칸(빈 입력 필드) 스타일 */
-        #templateMount .tpl-bodyBox .input-field-outside-empty{
-            display:inline-block;
-            min-width:90px;
-            padding:6px 10px;
-            border:1px solid #e0e0e0;
-            border-radius:10px;
-            background:#fafafa;
-            vertical-align: baseline;
+        /* TipTap InputField 보호 */
+        .tpl-bodyBox input[data-input-field]{
+            pointer-events:none;
+            background-color:#f5f5f5;
+            border:1px dashed #bbb;
+            padding:4px 6px;
+            border-radius:6px;
         }
 
-        /* =========================
-           Footer Buttons
-        ========================= */
-        body{ padding-bottom: 92px; }
+        body{padding-bottom:92px}
 
         .tpl-footer{
             position:fixed;
-            left:0; right:0; bottom:0;
+            left:0;right:0;bottom:0;
             background:rgba(255,255,255,0.92);
-            backdrop-filter: blur(6px);
+            backdrop-filter:blur(6px);
             border-top:1px solid #e6e6e6;
             padding:12px 0;
             z-index:9999;
@@ -226,55 +179,19 @@
             font-weight:700;
         }
 
-        .tpl-danger{
-            background:#fff;
-            border-color:#ff4d4f;
-            color:#ff4d4f;
-        }
+        .tpl-danger{background:#fff;border-color:#ff4d4f;color:#ff4d4f}
+        .tpl-danger:hover{background:#ff4d4f;color:#fff}
 
-        .tpl-danger:hover{
-            background:#ff4d4f;
-            color:#fff;
-        }
+        #tplEditBtn{background:#2c5cff;border-color:#2c5cff;color:#fff}
+        #tplEditBtn:hover{filter:brightness(0.95)}
 
-        /* 수정하기 버튼 강조 */
-        #tplEditBtn{
-            background:#2c5cff;
-            border-color:#2c5cff;
-            color:#fff;
+        .role-employee #tplEditBtn,
+        .role-employee #tplDeleteBtn{
+            display:none !important;
         }
-        #tplEditBtn:hover{ filter: brightness(0.95); }
-
     </style>
 </head>
-<template id="presetLeftTemplate">
-    <table class="preset-no-col-resize preset-left">
-        <tbody>
-        <tr><td>부서명</td><td></td></tr>
-        <tr><td>작성자</td><td></td></tr>
-        <tr><td>제목</td><td></td></tr>
-        <tr><td>작성일</td><td></td></tr>
-        </tbody>
-    </table>
-</template>
-
-<template id="presetRightTemplate">
-    <table class="preset-no-col-resize preset-right">
-        <tr>
-            <th>결재자</th>
-            <th>결재자1</th>
-            <th>결재자2</th>
-            <th>결재자3</th>
-            <th>결재자4</th>
-            <th>결재자5</th>
-        </tr>
-        <tr>
-            <th>서명</th>
-            <td></td><td></td><td></td><td></td><td></td>
-        </tr>
-    </table>
-</template>
-<body>
+<body th:classappend="${#authorization.expression('hasRole(''EMPLOYEE'')')} ? 'role-employee' : ''">
 <div id="tplHeaderRoot" class="tpl-header">
     <div class="tpl-titleLine">
         <h1 class="tpl-title" id="tplTitle">-</h1>
@@ -317,6 +234,43 @@
         "@tiptap/extension-text-style": "https://esm.sh/@tiptap/extension-text-style@2.11.2?target=es2020"
       }
     }
+</script>
+<script>
+    (function () {
+        function parseJwtPayload(token) {
+            try {
+                const t = token.replace(/^Bearer\s+/i, '');
+                const base64 = t.split('.')[1];
+                if (!base64) return null;
+                const json = decodeURIComponent(
+                    atob(base64.replace(/-/g, '+').replace(/_/g, '/'))
+                        .split('')
+                        .map(c => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+                        .join('')
+                );
+                return JSON.parse(json);
+            } catch (_) {
+                return null;
+            }
+        }
+
+        function getUserRole() {
+            const token = (localStorage.getItem('accessToken') || '').trim();
+            const p = parseJwtPayload(token) || {};
+            const role =
+                p.role ||
+                p.auth ||
+                (Array.isArray(p.authorities) ? p.authorities[0] : null) ||
+                (Array.isArray(p.roles) ? p.roles[0] : null) ||
+                '';
+            return String(role).replace(/^ROLE_/, '');
+        }
+
+        // EMPLOYEE면 버튼 숨김 (DOM은 남겨둬야 detail-form.js가 mustEl로 잡을 때 에러 안 남)
+        if (getUserRole() === 'EMPLOYEE') {
+            document.documentElement.classList.add('role-employee');
+        }
+    })();
 </script>
 <script type="module">
     import '/js/document-form/detail-form.js';

--- a/src/main/resources/templates/document-form/form-list.html
+++ b/src/main/resources/templates/document-form/form-list.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ko"
+      th:classappend="${#authorization.expression('hasRole(''EMPLOYEE'')')} ? 'role-employee' : ''">
 <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -16,7 +17,6 @@
         .card{background:var(--card); border:1px solid var(--line); border-radius:14px; box-shadow:0 4px 18px rgba(0,0,0,.06);}
         .header{display:flex; align-items:flex-start; justify-content:space-between; padding:18px 18px 12px;}
         .title{font-size:18px; font-weight:900; margin:0;}
-        .sub{margin:6px 0 0; color:var(--muted); font-size:13px; line-height:1.4;}
         .actions{display:flex; gap:10px; align-items:center;}
         .btn{border:1px solid var(--line); background:#fff; padding:10px 12px; border-radius:10px; cursor:pointer; font-weight:800;}
         .btn.primary{background:var(--primary); color:#fff; border-color:transparent;}
@@ -27,12 +27,21 @@
         .input, .select{border:1px solid var(--line); background:#fff; padding:10px 12px; border-radius:10px; outline:none;}
         .input{min-width:260px;}
         .select{min-width:140px;}
-        .rightHint{margin-left:auto; color:var(--muted); font-size:13px;}
-        code.k{background:#1118270d; padding:2px 6px; border-radius:6px;}
 
         .table-wrap{padding:0 18px 18px;}
         table{width:100%; border-collapse:separate; border-spacing:0; overflow:hidden; border:1px solid var(--line); border-radius:12px;}
-        thead th{background:#fafbff; text-align:left; font-size:13px; color:#374151; padding:12px 10px; border-bottom:1px solid var(--line);}
+        thead th{background:#fafbff; font-size:13px; color:#374151; padding:12px 10px; border-bottom:1px solid var(--line);}
+
+        /* 첫 번째 열(선택/번호)만 중앙 정렬 */
+        th.col-select, td.col-select { text-align:center; }
+
+        /* 제목 헤더만 중앙 / 본문은 왼쪽 유지 + 시작점 살짝 오른쪽 */
+        th.col-title { text-align:center; }
+        td.col-title { text-align:left; padding-left:30px; }
+
+        /* 체크박스 + 번호 정렬용 래퍼 */
+        .selWrap{ display:inline-flex; align-items:center; justify-content:center; gap:10px; }
+
         tbody td{padding:12px 10px; border-bottom:1px solid #f0f1f6; font-size:14px; vertical-align:middle;}
         tbody tr:hover{background:#fbfcff;}
         .muted{color:var(--muted); font-size:13px;}
@@ -48,6 +57,13 @@
 
         .toast{position:fixed; right:18px; bottom:18px; background:#111827; color:#fff; padding:10px 12px; border-radius:10px; opacity:0; transform:translateY(8px); transition:.18s;}
         .toast.show{opacity:1; transform:translateY(0);}
+
+        /* EMPLOYEE: 생성/삭제/선택 UI 제거 */
+        .role-employee #btnCreate,
+        .role-employee #btnDeleteSelected,
+        .role-employee input[data-role="rowCheck"]{
+            display:none !important;
+        }
     </style>
 </head>
 
@@ -56,11 +72,6 @@
     <div class="header">
         <div>
             <h1 class="title">문서양식 목록</h1>
-            <p class="sub">
-                View 라우팅: <code class="k">/form/forms</code><br/>
-                상세: <code class="k">/form/{docfoNo}</code>, 생성: <code class="k">/form/new</code><br/>
-                * 이 목록은 기본적으로 승인(A) 양식만 보여주는 페이지로 사용(서버가 기본 A가 아니면 JS에서 A로 요청)
-            </p>
         </div>
         <div class="actions">
             <button class="btn" id="btnRefresh" type="button">새로고침</button>
@@ -75,20 +86,15 @@
             <option value="30">30개</option>
         </select>
         <button class="btn" id="btnSearch" type="button">검색</button>
-
-        <button class="btn danger" id="btnBulkDelete" type="button" style="display:none;">선택 삭제</button>
-
-        <div class="rightHint">
-            API: <code class="k" id="apiLabel">/api/v1/forms</code>
-        </div>
+        <button class="btn danger" id="btnDeleteSelected" type="button" disabled>선택 삭제</button>
     </div>
 
     <div class="table-wrap">
         <table>
             <thead>
             <tr>
-                <th style="width:140px;">선택/번호</th>
-                <th>제목</th>
+                <th class="col-select" style="width:140px;">선택/번호</th>
+                <th class="col-title">제목</th>
             </tr>
             </thead>
             <tbody id="tbody">
@@ -105,7 +111,6 @@
 
 <div class="toast" id="toast"></div>
 
-<!-- static 리소스 경로 -->
 <script src="/js/document-form/list.js" defer></script>
 </body>
 </html>

--- a/src/main/resources/templates/document-form/pending-form-list.html
+++ b/src/main/resources/templates/document-form/pending-form-list.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html lang="ko">
+<html lang="ko"
+      th:classappend="${#authorization.expression('hasRole(''THR_ADMIN'')')} ? 'role-thr-admin' : ''">
 <head>
     <meta charset="UTF-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
@@ -161,6 +162,9 @@
             transition: .18s;
         }
         .toast.show { opacity: 1; transform: translateY(0); }
+
+        .statPill.W { background:#eff6ff; border-color:#bfdbfe; color:#1d4ed8; }
+        .statPill.X { background:#fdf2f8; border-color:#fbcfe8; color:#9d174d; }
     </style>
 </head>
 
@@ -181,9 +185,9 @@
 
     <div class="toolbar">
         <select class="select" id="statMode">
-            <option value="PR" selected>대기(P) + 반려(R)</option>
-            <option value="P">대기(P)만</option>
-            <option value="R">반려(R)만</option>
+            <option value="ALL" selected>전체</option>
+            <option value="P">대기</option>
+            <option value="R">반려</option>
         </select>
 
         <select class="select" id="size">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용
- EMPLOYEE 문서 생성/수정/삭제 제한
- EMPLOYEE pending.html 접근 거부
- THIRD-ADMIN pending에서 승인/반려 버튼 안 보이도록 조치
- 문서양식 삭제 시 승인/반려기능 추가
- 문서양식 삭제 반려 시 승인된 문서양식 목록에서 조회 가능하도록 변경

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
