### PR TITLE
feat : 알림 redis로 여러 서버에서 모두 알림 가게 구현

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/NotificationRedisMessage.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/NotificationRedisMessage.java
@@ -1,0 +1,20 @@
+package com.multi.mlpenterpriseapprovalsystem.notification.redis;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * redismessage dto
+ *
+ * @author : 김승기
+ * @filename : NotificationRedisMessage
+ * @since : 2026. 1. 6. 화요일
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class NotificationRedisMessage {
+    private String empId;
+    private Long notiNo;
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/NotificationRedisPubSubConfig.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/NotificationRedisPubSubConfig.java
@@ -1,0 +1,40 @@
+package com.multi.mlpenterpriseapprovalsystem.notification.redis;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+/**
+ * 알림함 redis config
+ *
+ * @author : 김승기
+ * @filename : NotificationRedisPubSubConfig
+ * @since : 2026. 1. 6. 화요일
+ */
+@Configuration
+@RequiredArgsConstructor
+public class NotificationRedisPubSubConfig {
+
+    @Bean(name = "notificationTopic")
+    public ChannelTopic notificationTopic() {
+        return new ChannelTopic("notifications:pubsub");
+    }
+
+    @Bean(name = "notificationRedisMessageListenerContainer")
+    public RedisMessageListenerContainer notificationRedisMessageListenerContainer(
+            RedisConnectionFactory connectionFactory,
+            RedisNotificationSubscriber subscriber,
+            @Qualifier("notificationTopic") ChannelTopic notificationTopic
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        container.setConnectionFactory(connectionFactory);
+
+        container.addMessageListener(subscriber, notificationTopic);
+
+        return container;
+    }
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/RedisNotificationPublisher.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/RedisNotificationPublisher.java
@@ -1,0 +1,39 @@
+package com.multi.mlpenterpriseapprovalsystem.notification.redis;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.stereotype.Service;
+
+/**
+ * 알림함 publisher
+ *
+ * @author : 김승기
+ * @filename : RedisNotificationPublisher
+ * @since : 2026. 1. 6. 화요일
+ */
+@Service
+@RequiredArgsConstructor
+public class RedisNotificationPublisher {
+
+    private final StringRedisTemplate stringRedisTemplate;
+    @Qualifier("notificationTopic")
+    private final ChannelTopic notificationTopic;
+    private final ObjectMapper objectMapper;
+
+    public void publish(String empId, Long notiNo) {
+        NotificationRedisMessage msg = new NotificationRedisMessage(empId, notiNo);
+
+        final String payload;
+        try {
+            payload = objectMapper.writeValueAsString(msg);
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException("Failed to serialize NotificationRedisMessage", e);
+        }
+
+        stringRedisTemplate.convertAndSend(notificationTopic.getTopic(), payload);
+    }
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/RedisNotificationSubscriber.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/RedisNotificationSubscriber.java
@@ -1,0 +1,74 @@
+package com.multi.mlpenterpriseapprovalsystem.notification.redis;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.multi.mlpenterpriseapprovalsystem.common.sse.SseManager;
+import com.multi.mlpenterpriseapprovalsystem.employee.enums.MsgStat;
+import com.multi.mlpenterpriseapprovalsystem.employee.repository.EmployeeRepository;
+import com.multi.mlpenterpriseapprovalsystem.notification.domain.Notifications;
+import com.multi.mlpenterpriseapprovalsystem.notification.dto.NotificationResponseDto;
+import com.multi.mlpenterpriseapprovalsystem.notification.repository.NotificationsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 알림 subscriber
+ *
+ * @author : 김승기
+ * @filename : RedisNotificationSubscriber
+ * @since : 2026. 1. 6. 화요일
+ */
+@Component
+@RequiredArgsConstructor
+public class RedisNotificationSubscriber implements MessageListener {
+
+    private final ObjectMapper objectMapper;
+    private final NotificationsRepository notificationsRepository;
+    private final EmployeeRepository employeeRepository;
+    private final SseManager sseManager;
+
+    /**
+     * Redis Pub/Sub 메시지 수신 엔트리 포인트
+     * (MessageListenerAdapter가 이 메서드를 호출)
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public void onMessage(Message message, byte[] pattern) {
+        System.out.println("[NOTI SUB] hit");
+        String raw = new String(message.getBody(), StandardCharsets.UTF_8);
+
+        final NotificationRedisMessage msg;
+        try {
+            msg = objectMapper.readValue(raw, NotificationRedisMessage.class);
+        } catch (Exception e) {
+            return;
+        }
+
+        String empId = msg.getEmpId();
+        Long notiNo = msg.getNotiNo();
+
+        System.out.println("=============================EMPID NOTINO "+ empId + notiNo);
+
+        boolean focus = employeeRepository.findByEmpId(empId)
+                .map(emp -> emp.getMsgStat() == MsgStat.FOCUS)
+                .orElse(false);
+        if (focus) return;
+
+        Notifications noti = notificationsRepository.findById(notiNo).orElse(null);
+        if (noti == null) return;
+
+        long unreadCount = notificationsRepository.countByReceiver_EmpIdAndIsReadFalse(empId);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("notification", NotificationResponseDto.fromEntity(noti));
+        data.put("unreadCount", unreadCount);
+
+        sseManager.sendToUser(empId, "notification", data);
+    }
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/service/NotificationService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/service/NotificationService.java
@@ -4,23 +4,23 @@ import com.multi.mlpenterpriseapprovalsystem.common.exception.CustomException;
 import com.multi.mlpenterpriseapprovalsystem.common.exception.ErrorCode;
 import com.multi.mlpenterpriseapprovalsystem.common.sse.SseManager;
 import com.multi.mlpenterpriseapprovalsystem.employee.domain.Employee;
-import com.multi.mlpenterpriseapprovalsystem.employee.enums.MsgStat;
 import com.multi.mlpenterpriseapprovalsystem.employee.repository.EmployeeRepository;
 import com.multi.mlpenterpriseapprovalsystem.notification.domain.NotificationType;
 import com.multi.mlpenterpriseapprovalsystem.notification.domain.Notifications;
 import com.multi.mlpenterpriseapprovalsystem.notification.dto.NotificationResponseDto;
+import com.multi.mlpenterpriseapprovalsystem.notification.redis.RedisNotificationPublisher;
 import com.multi.mlpenterpriseapprovalsystem.notification.repository.NotificationsRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 /**
@@ -37,6 +37,8 @@ public class NotificationService {
     private final SseManager sseManager;
     private final EmployeeRepository employeeRepository;
 
+    private final RedisNotificationPublisher redisNotificationPublisher;
+
     @Transactional
     public void sendNotification(Employee receiver, NotificationType type, String title, String content, String url) {
         Notifications noti = Notifications.builder()
@@ -47,20 +49,15 @@ public class NotificationService {
                 .title(title)
                 .url(url)
                 .build();
+
         notificationsRepository.save(noti);
 
-        long unreadCount = notificationsRepository.countByReceiver_EmpIdAndIsReadFalse(receiver.getEmpId());
-
-        if (receiver.getMsgStat()== MsgStat.FOCUS){
-            return;
-        }
-
-
-        Map<String, Object> data = new HashMap<>();
-        data.put("notification", NotificationResponseDto.fromEntity(noti));
-        data.put("unreadCount", unreadCount);
-
-        sseManager.sendToUser(receiver.getEmpId(), "notification", data);
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                redisNotificationPublisher.publish(receiver.getEmpId(), noti.getNotiNo());
+            }
+        });
     }
 
     @Transactional


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #353

## 📝 작업 내용
- 알림 redis 퍼블리셔, 서브스크라이버, config 구현 및 서비스 수정
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
