### PR TITLE
feat: 요금제 변경 로직 수정

### DIFF
--- a/sql/create.sql
+++ b/sql/create.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS subscription (
                                             CONSTRAINT uk_subscription_name UNIQUE (sub_name),
                                             CONSTRAINT ck_subscription_name CHECK (sub_name IN ('basic','pro','ultimate'))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+ALTER TABLE subscription DROP CONSTRAINT ck_subscription_name;
 
 -- 2) 회사 (✅ role 컬럼 반영)
 CREATE TABLE IF NOT EXISTS company (

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/exception/ErrorCode.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/exception/ErrorCode.java
@@ -132,6 +132,7 @@ public enum ErrorCode {
     SUBSCRIPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "SUBSCRIPTION_NOT_FOUND", "해당 회사의 구독 정보를 찾을 수 없습니다"),
     ALREADY_FREE_PLAN(HttpStatus.CONFLICT, "ALREADY_FREE_PLAN", "이미 무료 요금제입니다"),
     ALREADY_CANCELED_SUBSCRIPTION(HttpStatus.CONFLICT, "ALREADY_CANCELED_SUBSCRIPTION", "이미 해지 예약된 상태입니다"),
+    ALREADY_PENDING_PLAN(HttpStatus.CONFLICT, "ALREADY_PENDING_PLAN", "이미 해당 요금제로 변경 예약된 상태입니다"),
 
     // 결제 실패
     PAYMENT_FAILED(HttpStatus.BAD_REQUEST, "PAYMENT_FAILED", "결제에 실패했습니다"),

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/payment/service/PortoneService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/payment/service/PortoneService.java
@@ -19,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.Map;
 
@@ -114,41 +115,193 @@ public class PortoneService {
     }
 
     // 즉시 결제 요청
-    public void subscribeProPlan(String comId, Long subNo) {
-        // 1. 필요한 정보 조회 (회사, 선택한 요금제, 등록된 카드)
-        CompanySubscription companySub = companySubscriptionRepository.findByCompany_ComId(comId)
-                .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+//    public void subscribeProPlan(String comId, Long subNo) {
+//        // 1. 필요한 정보 조회 (회사, 선택한 요금제, 등록된 카드)
+//        CompanySubscription companySub = companySubscriptionRepository.findByCompany_ComId(comId)
+//                .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+//
+//        Subscription plan = subscriptionRepository.findById(subNo)
+//                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+//
+//        PaymentMethod paymentMethod = companySub.getPaymentMethod();
+//        if (paymentMethod == null || !paymentMethod.getActive()) {
+//            throw new CustomException(ErrorCode.PAYMENT_METHOD_NOT_FOUND); // "유효한 결제 수단이 없습니다."
+//        }
+//
+//        // 2. 즉시 결제 요청 (주문번호는 회사번호+시간 등으로 생성)
+//        String merchantUid = "SUB_" + comId + "_" + System.currentTimeMillis();
+//        Map<String, Object> response = requestrecurrentPayment(
+//                paymentMethod.getBillingKey(),
+//                plan.getSubPrice(),
+//                merchantUid,
+//                plan.getSubName()
+//        );
+//
+//        // 3. 결제 결과 확인 및 구독 상태 업데이트
+//        Integer code = (Integer) response.get("code");
+//        if (code == 0) { // 결제 성공
+//            // 구독 상태 업데이트 (한 달 뒤 결제 예정)
+//            companySub.renew(LocalDateTime.now().plusMonths(1));
+//            // 요금제 정보 업데이트
+//            companySub.updatePlan(plan); // 엔티티에 메서드 추가 필요
+//
+//            // 결제 내역 저장
+//            paymentHistoryRepository.save(new PaymentHistory(companySub.getCompany(), plan.getSubPrice(), true, paymentMethod));
+//        } else {
+//            throw new CustomException(ErrorCode.PAYMENT_FAILED);
+//        }
+//    }
+//    public void subscribeProPlan(String comId, Long subNo) {
+//        CompanySubscription companySub = companySubscriptionRepository.findByCompany_ComId(comId)
+//                .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+//        Subscription targetPlan = subscriptionRepository.findById(subNo)
+//                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+//
+//        if (companySub.getPendingSubscription() != null &&
+//                companySub.getPendingSubscription().getSubNo().equals(targetPlan.getSubNo().intValue())) {
+//            throw new CustomException(ErrorCode.ALREADY_PENDING_PLAN);
+//        }
+//
+//        BigDecimal currentPrice = companySub.getSubscription().getSubPrice();
+//        BigDecimal targetPrice = targetPlan.getSubPrice();
+//
+//        // 1. [다운그레이드 케이스] 현재보다 싼 요금제 선택 시 (0원 포함)
+//        if (targetPrice.compareTo(currentPrice) < 0) {
+//            log.info("[다운그레이드 예약] {} 요금제로 예약 변경 : {}", targetPlan.getSubName(), comId);
+//            companySub.reservePlanChange(targetPlan); // 엔티티의 예약 메서드 호출
+//            return;
+//        }
+//
+//        // 2. [업그레이드 케이스] 차액 결제(Proration) 로직 수행
+//        BigDecimal amountToPay = targetPrice; // 기본값은 전액
+//
+//        // [수정 포인트] 상태가 ACTIVE 또는 CANCELED이면서 만료일이 미래인 경우 차액 계산 적용
+//        boolean isEligibleForProration = (companySub.getStatus() == SubStatus.ACTIVE || companySub.getStatus() == SubStatus.CANCELED)
+//                && companySub.getNextBillingDate() != null
+//                && companySub.getNextBillingDate().isAfter(LocalDateTime.now());
+//
+//        if (isEligibleForProration) {
+//            // 남은 일수 계산 (한 달을 30일로 가정)
+//            long remainingDays = java.time.Duration.between(LocalDateTime.now(), companySub.getNextBillingDate()).toDays();
+//            remainingDays = Math.max(0, remainingDays);
+//
+//            if (remainingDays > 0) {
+//                // 남은 기간의 가치 = (현재 가격 / 30) * 남은 일수
+//                BigDecimal dayValue = currentPrice.divide(new BigDecimal("30"), 2, java.math.RoundingMode.HALF_UP);
+//                BigDecimal remainingValue = dayValue.multiply(new BigDecimal(remainingDays));
+//
+//                // 실제 결제액 = 목표 요금제 가격 - 남은 가치 (최소 100원 결제 보장)
+//                amountToPay = targetPrice.subtract(remainingValue).max(new BigDecimal("100"));
+//                log.info("[차액 결제 계산] 목표: {}, 남은가치: {}, 최종결제액: {}", targetPrice, remainingValue, amountToPay);
+//            }
+//        }
+//
+//        // 3. 포트원 결제 실행
+//        PaymentMethod paymentMethod = companySub.getPaymentMethod();
+//        String merchantUid = "UPGRADE_" + comId + "_" + System.currentTimeMillis();
+//
+//        Map<String, Object> response = requestrecurrentPayment(
+//                paymentMethod.getBillingKey(), amountToPay, merchantUid, targetPlan.getSubName() + " 업그레이드"
+//        );
+//
+//        if ((Integer) response.get("code") == 0) {
+//            companySub.renew(LocalDateTime.now().plusMonths(1)); // 주기 새로 시작
+//            companySub.updatePlan(targetPlan);
+//            companySub.clearPendingPlan(); // 업그레이드 성공 시 예약 정보 삭제
+//            paymentHistoryRepository.save(new PaymentHistory(companySub.getCompany(), amountToPay, true, paymentMethod));
+//        } else {
+//            throw new CustomException(ErrorCode.PAYMENT_FAILED);
+//        }
+//    }
 
-        Subscription plan = subscriptionRepository.findById(subNo)
+    public void subscribeProPlan(String comId, Long subNo) {
+        CompanySubscription sub = companySubscriptionRepository.findByCompany_ComId(comId)
+                .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+        Subscription targetPlan = subscriptionRepository.findById(subNo)
                 .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
 
-        PaymentMethod paymentMethod = companySub.getPaymentMethod();
-        if (paymentMethod == null || !paymentMethod.getActive()) {
-            throw new CustomException(ErrorCode.PAYMENT_METHOD_NOT_FOUND); // "유효한 결제 수단이 없습니다."
+        // 1. 중복 요청 체크
+        if (sub.getPendingSubscription() != null && sub.getPendingSubscription().getSubNo().equals(targetPlan.getSubNo())) {
+            throw new CustomException(ErrorCode.ALREADY_PENDING_PLAN);
         }
 
-        // 2. 즉시 결제 요청 (주문번호는 회사번호+시간 등으로 생성)
-        String merchantUid = "SUB_" + comId + "_" + System.currentTimeMillis();
-        Map<String, Object> response = requestrecurrentPayment(
-                paymentMethod.getBillingKey(),
-                plan.getSubPrice(),
-                merchantUid,
-                plan.getSubName()
-        );
+        // 2. [핵심] 계층(Level) 기반 업그레이드 판단
+        int currentLevel = getPlanLevel(sub.getSubscription().getSubNo());
+        int targetLevel = getPlanLevel(targetPlan.getSubNo());
 
-        // 3. 결제 결과 확인 및 구독 상태 업데이트
-        Integer code = (Integer) response.get("code");
-        if (code == 0) { // 결제 성공
-            // 구독 상태 업데이트 (한 달 뒤 결제 예정)
-            companySub.renew(LocalDateTime.now().plusMonths(1));
-            // 요금제 정보 업데이트
-            companySub.updatePlan(plan); // 엔티티에 메서드 추가 필요
+        // 타겟 레벨이 현재보다 낮으면 -> 다운그레이드 (예약 처리)
+        if (targetLevel < currentLevel) {
+            log.info("[다운그레이드 예약] {} (L{}) -> {} (L{})",
+                    sub.getSubscription().getSubName(), currentLevel, targetPlan.getSubName(), targetLevel);
+            sub.reservePlanChange(targetPlan);
+            return;
+        }
 
-            // 결제 내역 저장
-            paymentHistoryRepository.save(new PaymentHistory(companySub.getCompany(), plan.getSubPrice(), true, paymentMethod));
+        // --- 여기서부터는 즉시 업그레이드(전환) 로직 ---
+
+        // 3. 기존 요금제의 잔여 가치를 예치금으로 전환
+        if (sub.getNextBillingDate() != null && sub.getStatus() != SubStatus.FREE) {
+            long remainingDays = java.time.Duration.between(LocalDateTime.now(), sub.getNextBillingDate()).toDays();
+            remainingDays = Math.max(0, remainingDays);
+
+            if (remainingDays > 0) {
+                // 1일당 가치 계산 (소수점 2자리까지 유지하여 계산 정확도 확보)
+                BigDecimal dayValue = sub.getSubscription().getSubPrice().divide(new BigDecimal("30"), 2, RoundingMode.HALF_UP);
+
+                // [수정 포인트] 최종 적립 금액 계산 시 정수로 반올림(setScale(0)) 처리
+                BigDecimal remainingValue = dayValue.multiply(new BigDecimal(remainingDays))
+                        .setScale(0, RoundingMode.HALF_UP);
+
+                sub.addCredit(remainingValue);
+                log.info("[예치금 적립] 소수점 제거된 정수 금액: {}", remainingValue);
+            }
+        }
+
+        // 4. 새 요금제 결제액 계산 (새 가격 - 현재 보유 예치금)
+        BigDecimal targetPrice = targetPlan.getSubPrice();
+        BigDecimal amountToPay = targetPrice.subtract(sub.getCreditBalance()).max(BigDecimal.ZERO);
+
+        // 5. 예치금 차감 (새 가격만큼 소진)
+        sub.useCredit(targetPrice);
+
+        // 6. 실행 (결제 또는 예치금 100% 처리)
+        if (amountToPay.compareTo(BigDecimal.ZERO) == 0) {
+            log.info("[즉시 업그레이드] 예치금 전액 처리 완료");
+            sub.updatePlan(targetPlan);
+            sub.renew(LocalDateTime.now().plusMonths(1));
+            sub.clearPendingPlan();
         } else {
-            throw new CustomException(ErrorCode.PAYMENT_FAILED);
+            PaymentMethod paymentMethod = sub.getPaymentMethod();
+            String merchantUid = "UPGRADE_" + comId + "_" + System.currentTimeMillis();
+            Map<String, Object> response = requestrecurrentPayment(paymentMethod.getBillingKey(), amountToPay, merchantUid, targetPlan.getSubName());
+
+            if ((Integer) response.get("code") == 0) {
+                sub.updatePlan(targetPlan);
+                sub.renew(LocalDateTime.now().plusMonths(1));
+                sub.clearPendingPlan();
+                paymentHistoryRepository.save(new PaymentHistory(sub.getCompany(), amountToPay, true, paymentMethod));
+            } else {
+                throw new CustomException(ErrorCode.PAYMENT_FAILED);
+            }
         }
+    }
+
+    /**
+     * 요금제 계층(Level) 매핑 헬퍼 메서드
+     */
+    private int getPlanLevel(Integer subNo) {
+        return switch (subNo) {
+            case 1 -> 1; // Basic30
+            case 2 -> 2; // Pro30
+            case 3 -> 3; // Ultimate30
+            case 4 -> 4; // Basic50 (인원 확장)
+            case 5 -> 5; // Pro50
+            case 6 -> 6; // Ultimate50
+            case 7 -> 7; // Basic100 (인원 확장)
+            case 8 -> 8; // Pro100
+            case 9 -> 9; // Ultimate100
+            default -> 1;
+        };
     }
 
 
@@ -174,24 +327,49 @@ public class PortoneService {
     /**
      * 구독 해지 예약 (자동 갱신 취소)
      */
+//    public void cancelSubscription(String comId) {
+//        // 1. 해당 회사의 구독 정보 조회
+//        CompanySubscription companySub = companySubscriptionRepository.findByCompany_ComId(comId)
+//                .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
+//
+//        // 2. 이미 FREE 상태이거나 이미 취소된 경우 체크
+//        if (companySub.getStatus() == SubStatus.FREE) {
+//            throw new CustomException(ErrorCode.ALREADY_FREE_PLAN); // "이미 무료 요금제 사용 중입니다"
+//        }
+//
+//        if (!companySub.isAutoRenewal() || companySub.getStatus() == SubStatus.CANCELED) {
+//            throw new CustomException(ErrorCode.ALREADY_CANCELED_SUBSCRIPTION); // "이미 해지 예약된 상태입니다"
+//        }
+//
+//        // 3. 엔티티의 해지 로직 호출 (autoRenewal = false, status = CANCELED)
+//        companySub.cancelSubscription();
+//
+//        log.info("[구독 해지 예약 완료] 회사: {}, 만료 예정일: {}", comId, companySub.getNextBillingDate());
+//    }
+    /**
+     * 구독 해지 예약 (자동 갱신 취소 및 무료 전환 예약)
+     */
     public void cancelSubscription(String comId) {
         // 1. 해당 회사의 구독 정보 조회
         CompanySubscription companySub = companySubscriptionRepository.findByCompany_ComId(comId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
 
-        // 2. 이미 FREE 상태이거나 이미 취소된 경우 체크
+        // 2. 이미 완전한 무료 상태인 경우만 체크
         if (companySub.getStatus() == SubStatus.FREE) {
-            throw new CustomException(ErrorCode.ALREADY_FREE_PLAN); // "이미 무료 요금제 사용 중입니다"
+            throw new CustomException(ErrorCode.ALREADY_FREE_PLAN);
         }
 
-        if (!companySub.isAutoRenewal() || companySub.getStatus() == SubStatus.CANCELED) {
-            throw new CustomException(ErrorCode.ALREADY_CANCELED_SUBSCRIPTION); // "이미 해지 예약된 상태입니다"
+        // 이미 CANCELED 상태이고 예약된 요금제도 없는(이미 무료 전환 확정) 경우에만 에러를 던집니다.
+        // 만약 pendingSubscription이 있다면, 그것을 지우고 '순수 해지(무료 전환)'로 변경할 수 있게 합니다.
+        if (companySub.getStatus() == SubStatus.CANCELED && companySub.getPendingSubscription() == null) {
+            throw new CustomException(ErrorCode.ALREADY_CANCELED_SUBSCRIPTION);
         }
 
-        // 3. 엔티티의 해지 로직 호출 (autoRenewal = false, status = CANCELED)
-        companySub.cancelSubscription();
+        // 3. 비즈니스 로직 수행
+        companySub.clearPendingPlan();   // 예약된 유료 요금제 정보 삭제 (이제 만료 후 무료가 됨)
+        companySub.cancelSubscription(); // autoRenewal = false, status = CANCELED 설정
 
-        log.info("[구독 해지 예약 완료] 회사: {}, 만료 예정일: {}", comId, companySub.getNextBillingDate());
+        log.info("[구독 해지 업데이트] 회사: {}, 이제 만료일 이후 무료 요금제로 전환됩니다.", comId);
     }
 
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/domain/CompanySubscription.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/domain/CompanySubscription.java
@@ -7,6 +7,7 @@ import com.multi.mlpenterpriseapprovalsystem.subscription.enums.SubStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
@@ -49,6 +50,36 @@ public class CompanySubscription extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "sub_stat", nullable = false)
     private SubStatus status;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pending_sub_no")
+    private Subscription pendingSubscription; // 만료 후 변경될 예약 요금제
+
+    @Column(name = "credit_balance", nullable = false)
+    @Builder.Default
+    private BigDecimal creditBalance = BigDecimal.ZERO; // 예치금
+
+    // 예치금 추가 메서드
+    public void addCredit(BigDecimal amount) {
+        this.creditBalance = this.creditBalance.add(amount);
+    }
+
+    // 예치금 사용 메서드 (남은 예치금 반환)
+    public void useCredit(BigDecimal amount) {
+        this.creditBalance = this.creditBalance.subtract(amount).max(BigDecimal.ZERO);
+    }
+
+    // 요금제 예약 메서드 (다운그레이드용)
+    public void reservePlanChange(Subscription nextPlan) {
+        this.pendingSubscription = nextPlan;
+        this.autoRenewal = false; // 예약 변경이므로 다음 자동 결제는 막음
+        this.status = SubStatus.CANCELED; // 해지 예약과 유사한 상태로 취급
+    }
+
+    // 업그레이드 시 예약 정보 초기화
+    public void clearPendingPlan() {
+        this.pendingSubscription = null;
+    }
 
     // 결제 수단 변경
     public void changePaymentMethod(PaymentMethod newMethod) {

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/domain/Subscription.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/domain/Subscription.java
@@ -29,4 +29,7 @@ public class Subscription {
 
     @Column(nullable = false, precision = 8)
     private BigDecimal subPrice;
+
+    @Column(nullable = false)
+    private Integer subLimit;
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/dto/response/ResCompanySubscriptionDto.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/dto/response/ResCompanySubscriptionDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 /**
@@ -25,4 +26,11 @@ public class ResCompanySubscriptionDto {
     private SubStatus status;       // 구독 상태 (ACTIVE, FREE, CANCELED 등)
     private LocalDateTime nextBillingDate; // 다음 결제일
     private boolean autoRenewal;    // 자동 갱신 여부
+    private Integer pendingSubNo;  // 예약된 요금제 정보
+    private String pendingSubName; // 예약된 요금제 정보
+
+    private Integer empCnt;        // 현재 회사의 사원 수
+    private Integer pendingLimit;  // 예약된 요금제의 인원 한도
+    private BigDecimal creditBalance; // 예치금
+
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/dto/response/ResSubscriptionDto.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/dto/response/ResSubscriptionDto.java
@@ -24,4 +24,5 @@ public class ResSubscriptionDto {
     private String subName;
     private String subDesc;
     private BigDecimal subPrice;
+    private Integer subLimit;
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/scheduler/CompanySubscriptionScheduler.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/scheduler/CompanySubscriptionScheduler.java
@@ -1,7 +1,5 @@
 package com.multi.mlpenterpriseapprovalsystem.subscription.scheduler;
 
-import com.multi.mlpenterpriseapprovalsystem.common.exception.CustomException;
-import com.multi.mlpenterpriseapprovalsystem.common.exception.ErrorCode;
 import com.multi.mlpenterpriseapprovalsystem.payment.service.PortoneService;
 import com.multi.mlpenterpriseapprovalsystem.subscription.domain.CompanySubscription;
 import com.multi.mlpenterpriseapprovalsystem.subscription.domain.Subscription;
@@ -13,9 +11,11 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Please explain the class!!!
@@ -39,54 +39,167 @@ public class CompanySubscriptionScheduler {
      * 매일 새벽 2시에 실행되는 정기 결제 및 만료 처리 스케줄러
      */
     // 0 0 2 * * *
-    @Scheduled(cron = "0 0 2 * * *") // 매일 02:00:00 실행
+//    @Scheduled(cron = "0 0 2 * * *") // 매일 02:00:00 실행
+//    public void processSubscriptionBilling() {
+//        LocalDateTime now = LocalDateTime.now();
+//        // 오늘의 시작(00:00:00)부터 끝(23:59:59)까지의 범위를 설정
+//        LocalDateTime startOfDay = now.with(LocalTime.MIN);
+//        LocalDateTime endOfDay = now.with(LocalTime.MAX);
+//
+//        log.info("[스케줄러 시작] 결제 대상 조회 범위: {} ~ {}", startOfDay, endOfDay);
+//
+//        // 1. 오늘 결제 예정인 구독 정보 조회
+//        List<CompanySubscription> targets = companySubscriptionRepository
+//                .findAllByNextBillingDateBetween(startOfDay, endOfDay);
+//
+//        if (targets.isEmpty()) {
+//            log.info("[스케줄러] 오늘 처리할 결제 대상이 없습니다.");
+//            return;
+//        }
+//
+//        for (CompanySubscription sub : targets) {
+//            String comId = sub.getCompany().getComId();
+//
+//            try {
+//                if (sub.isAutoRenewal()) {
+//                    // CASE A: 자동 갱신인 경우 -> PortoneService를 통해 결제 시도
+//                    log.info("[자동 결제 시도] 회사: {}, 요금제: {}", comId, sub.getSubscription().getSubName());
+//
+//                    // 기존에 만든 subscribeProPlan 호출 (내부에서 결제 + 연장 + 이력저장 수행)
+//                    portoneService.subscribeProPlan(comId, sub.getSubscription().getSubNo().longValue());
+//
+//                    log.info("[자동 결제 성공] 회사: {}", comId);
+//                } else {
+//                    // CASE B: 자동 갱신이 꺼진 경우 (해지 예약 상태) -> 무료 요금제로 강등
+//                    log.info("[구독 만료 처리] 회사: {}, 자동갱신 꺼짐", comId);
+//
+//                    Subscription freePlan = subscriptionRepository.findById(1L) // 1번: basic(free) 요금제
+//                            .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+//
+//                    sub.downgradeToFree(freePlan);
+//
+//                    log.info("[무료 전환 완료] 회사: {}", comId);
+//                }
+//            } catch (Exception e) {
+//                // 결제 실패 시 에러 로그를 남기고 다음 대상으로 넘어감
+//                log.error("[결제 실패] 회사: {}, 사유: {}", comId, e.getMessage());
+//                // TODO: 여기에 결제 실패 알림(이메일 등) 로직을 추가
+//            }
+//        }
+//
+//        log.info("[스케줄러 종료] 총 {}건 처리 완료", targets.size());
+//    }
+//    @Scheduled(cron = "0 0 2 * * *") // 매일 새벽 2시 실행
+//    public void processSubscriptionBilling() {
+//        LocalDateTime now = LocalDateTime.now();
+//        LocalDateTime startOfDay = now.with(LocalTime.MIN);
+//        LocalDateTime endOfDay = now.with(LocalTime.MAX);
+//
+//        log.info("[스케줄러 시작] 결제 및 만료 처리 범위: {} ~ {}", startOfDay, endOfDay);
+//
+//        // 오늘이 차기 결제일(만료일)인 대상 조회
+//        List<CompanySubscription> targets = companySubscriptionRepository
+//                .findAllByNextBillingDateBetween(startOfDay, endOfDay);
+//
+//        for (CompanySubscription sub : targets) {
+//            String comId = sub.getCompany().getComId();
+//            try {
+//                if (sub.isAutoRenewal()) {
+//                    // CASE A: 정상 이용 중인 경우 -> 현재 요금제로 정기 결제 진행
+//                    log.info("[정기 결제] 회사: {}, 요금제: {}", comId, sub.getSubscription().getSubName());
+//                    portoneService.subscribeProPlan(comId, sub.getSubscription().getSubNo().longValue());
+//                }
+//                else {
+//                    // CASE B: 해지 예약(CANCELED) 상태인 경우 (만료일 도래)
+//                    Subscription pendingPlan = sub.getPendingSubscription(); // 예약된 요금제 확인
+//
+//                    if (pendingPlan != null) {
+//                        // 1. 예약된 요금제가 있는 경우 (유료 -> 낮은 유료로 다운그레이드)
+//                        log.info("[요금제 예약 전환] 회사: {}, {} -> {}", comId, sub.getSubscription().getSubName(), pendingPlan.getSubName());
+//
+//                        sub.updatePlan(pendingPlan); // 요금제 교체
+//                        sub.clearPendingPlan();      // 예약 정보 삭제
+//
+//                        // 새 요금제로 첫 정기 결제 시도 (성공 시 다시 ACTIVE 상태가 됨)
+//                        portoneService.subscribeProPlan(comId, pendingPlan.getSubNo().longValue());
+//                        log.info("[다운그레이드 완료 및 결제 성공] 회사: {}", comId);
+//                    }
+//                    else {
+//                        // 2. 예약된 요금제가 없는 경우 (유료 -> 무료로 완전 해지)
+//                        log.info("[구독 종료] 회사: {}, 무료 요금제 강등", comId);
+//
+//                        Subscription freePlan = subscriptionRepository.findById(1L)
+//                                .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
+//
+//                        sub.downgradeToFree(freePlan);
+//                        log.info("[무료 전환 완료] 회사: {}", comId);
+//                    }
+//                }
+//            } catch (Exception e) {
+//                log.error("[스케줄러 처리 실패] 회사: {}, 사유: {}", comId, e.getMessage());
+//                // TODO: 실패 알림(이메일/슬랙) 로직 추가
+//            }
+//        }
+//        log.info("[스케줄러 종료] 처리 완료");
+//    }
+
+    @Scheduled(cron = "0 0 2 * * *")
     public void processSubscriptionBilling() {
         LocalDateTime now = LocalDateTime.now();
-        // 오늘의 시작(00:00:00)부터 끝(23:59:59)까지의 범위를 설정
-        LocalDateTime startOfDay = now.with(LocalTime.MIN);
-        LocalDateTime endOfDay = now.with(LocalTime.MAX);
-
-        log.info("[스케줄러 시작] 결제 대상 조회 범위: {} ~ {}", startOfDay, endOfDay);
-
-        // 1. 오늘 결제 예정인 구독 정보 조회
         List<CompanySubscription> targets = companySubscriptionRepository
-                .findAllByNextBillingDateBetween(startOfDay, endOfDay);
-
-        if (targets.isEmpty()) {
-            log.info("[스케줄러] 오늘 처리할 결제 대상이 없습니다.");
-            return;
-        }
+                .findAllByNextBillingDateBetween(now.with(LocalTime.MIN), now.with(LocalTime.MAX));
 
         for (CompanySubscription sub : targets) {
             String comId = sub.getCompany().getComId();
+            int currentEmpCnt = sub.getCompany().getEmpCnt();
 
             try {
-                if (sub.isAutoRenewal()) {
-                    // CASE A: 자동 갱신인 경우 -> PortoneService를 통해 결제 시도
-                    log.info("[자동 결제 시도] 회사: {}, 요금제: {}", comId, sub.getSubscription().getSubName());
+                // 결제 혹은 전환할 타겟 요금제 결정
+                Subscription targetPlan = sub.isAutoRenewal() ? sub.getSubscription() : sub.getPendingSubscription();
+                if (targetPlan == null) targetPlan = subscriptionRepository.findById(1L).get(); // 기본 무료
 
-                    // 기존에 만든 subscribeProPlan 호출 (내부에서 결제 + 연장 + 이력저장 수행)
-                    portoneService.subscribeProPlan(comId, sub.getSubscription().getSubNo().longValue());
-
-                    log.info("[자동 결제 성공] 회사: {}", comId);
-                } else {
-                    // CASE B: 자동 갱신이 꺼진 경우 (해지 예약 상태) -> 무료 요금제로 강등
-                    log.info("[구독 만료 처리] 회사: {}, 자동갱신 꺼짐", comId);
-
-                    Subscription freePlan = subscriptionRepository.findById(1L) // 1번: basic(free) 요금제
-                            .orElseThrow(() -> new CustomException(ErrorCode.PLAN_NOT_FOUND));
-
-                    sub.downgradeToFree(freePlan);
-
-                    log.info("[무료 전환 완료] 회사: {}", comId);
+                // 인원수 체크
+                if (currentEmpCnt > targetPlan.getSubLimit()) {
+                    log.warn("[인원 초과] 기존 요금제 강제 유지 및 연장: {}", comId);
+                    targetPlan = sub.getSubscription(); // 기존 요금제로 강제 회귀
+                    sub.clearPendingPlan();
                 }
+
+                // --- [예치금 적용 로직] ---
+                BigDecimal monthlyPrice = targetPlan.getSubPrice();
+                // 실제 결제액 = 이번 달 요금 - 보유 예치금
+                BigDecimal finalAmount = monthlyPrice.subtract(sub.getCreditBalance()).max(BigDecimal.ZERO);
+
+                // 예치금 차감 (이번 달 요금만큼 소진)
+                sub.useCredit(monthlyPrice);
+                // ------------------------
+
+                if (finalAmount.compareTo(BigDecimal.ZERO) == 0) {
+                    // 예치금으로 전액 충당 시 결제 API 호출 없이 연장
+                    log.info("[정기 결제] 예치금 소진 처리 완료 (결제액 0원): {}", comId);
+                    sub.updatePlan(targetPlan);
+                    sub.renew(LocalDateTime.now().plusMonths(1));
+                } else {
+                    // 예치금 소진 후 남은 금액만 실제 결제 요청
+                    String merchantUid = "BILL_" + comId + "_" + System.currentTimeMillis();
+                    Map<String, Object> response = portoneService.requestrecurrentPayment(
+                            sub.getPaymentMethod().getBillingKey(), finalAmount, merchantUid, targetPlan.getSubName()
+                    );
+
+                    if ((Integer) response.get("code") == 0) {
+                        sub.updatePlan(targetPlan);
+                        sub.renew(LocalDateTime.now().plusMonths(1));
+                        log.info("[정기 결제 성공] 회사: {}, 결제금액: {}", comId, finalAmount);
+                    } else {
+                        throw new Exception("포트원 결제 실패");
+                    }
+                }
+                sub.clearPendingPlan(); // 처리 완료 후 예약 정보 삭제
+
             } catch (Exception e) {
-                // 결제 실패 시 에러 로그를 남기고 다음 대상으로 넘어감
-                log.error("[결제 실패] 회사: {}, 사유: {}", comId, e.getMessage());
-                // TODO: 여기에 결제 실패 알림(이메일 등) 로직을 추가
+                log.error("[스케줄러 실패] 회사: {}, 사유: {}", comId, e.getMessage());
+                // 실패 시 autoRenewal을 false로 바꾸거나 알림 발송 로직 추가 권장
             }
         }
-
-        log.info("[스케줄러 종료] 총 {}건 처리 완료", targets.size());
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/service/CompanySubscriptionService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/service/CompanySubscriptionService.java
@@ -3,6 +3,7 @@ package com.multi.mlpenterpriseapprovalsystem.subscription.service;
 import com.multi.mlpenterpriseapprovalsystem.common.exception.CustomException;
 import com.multi.mlpenterpriseapprovalsystem.common.exception.ErrorCode;
 import com.multi.mlpenterpriseapprovalsystem.subscription.domain.CompanySubscription;
+import com.multi.mlpenterpriseapprovalsystem.subscription.domain.Subscription;
 import com.multi.mlpenterpriseapprovalsystem.subscription.dto.response.ResCompanySubscriptionDto;
 import com.multi.mlpenterpriseapprovalsystem.subscription.repository.CompanySubscriptionRepository;
 import lombok.RequiredArgsConstructor;
@@ -29,12 +30,19 @@ public class CompanySubscriptionService {
         CompanySubscription sub = companySubscriptionRepository.findByCompany_ComId(comId)
                 .orElseThrow(() -> new CustomException(ErrorCode.SUBSCRIPTION_NOT_FOUND));
 
+        Subscription pending = sub.getPendingSubscription();
+
         return ResCompanySubscriptionDto.builder()
-                .subNo(sub.getSubscription().getSubNo()) // 현재 연결된 요금제 번호
+                .subNo(sub.getSubscription().getSubNo())
                 .subName(sub.getSubscription().getSubName())
                 .status(sub.getStatus())
                 .nextBillingDate(sub.getNextBillingDate())
                 .autoRenewal(sub.isAutoRenewal())
+                .pendingSubNo(pending != null ? pending.getSubNo() : null)
+                .pendingSubName(pending != null ? pending.getSubName() : null)
+                .empCnt(sub.getCompany().getEmpCnt())
+                .pendingLimit(pending != null ? pending.getSubLimit() : 30)
+                .creditBalance(sub.getCreditBalance())
                 .build();
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/service/SubscriptionService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/subscription/service/SubscriptionService.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -30,17 +29,14 @@ public class SubscriptionService {
     public List<ResSubscriptionDto> getSubscriptions() {
         List<Subscription> subscriptions = subscriptionRepository.findAll();
 
-        List<ResSubscriptionDto> resSubscriptionDtos = new ArrayList<>();
-        for (Subscription subscription : subscriptions) {
-            resSubscriptionDtos.add(
-                    ResSubscriptionDto.builder()
+        return subscriptions.stream()
+                .map(subscription -> ResSubscriptionDto.builder()
                         .subNo(subscription.getSubNo())
                         .subName(subscription.getSubName())
                         .subPrice(subscription.getSubPrice())
                         .subDesc(subscription.getSubDesc())
-                    .build());
-        }
-
-        return resSubscriptionDtos;
+                        .subLimit(subscription.getSubLimit())
+                        .build())
+                .toList();
     }
 }

--- a/src/main/resources/templates/subscription/list.html
+++ b/src/main/resources/templates/subscription/list.html
@@ -31,6 +31,21 @@
         .title{ font-size:52px; font-weight:900; margin:0; letter-spacing:-1.5px; }
         .desc{ color:#555; font-weight:600; margin-top:12px; font-size:18px; }
 
+        /* 예치금 배지 스타일 */
+        .credit-badge {
+            background: #eef3ff;
+            border: 1px solid var(--primary);
+            color: var(--primary);
+            padding: 8px 16px;
+            border-radius: 20px;
+            font-weight: 800;
+            font-size: 15px;
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 20px;
+        }
+
         .plan-container{
             display:flex;
             gap:24px;
@@ -69,14 +84,36 @@
         .plan-price{ font-size:44px; font-weight:900; margin-bottom:30px; }
         .plan-price span{ font-size:18px; font-weight:600; }
 
+        .usage-info{
+            margin-top:-20px;
+            margin-bottom:25px;
+        }
+
         .usage-period{
             font-size:14px;
             font-weight:700;
-            margin-top:-20px;
-            margin-bottom:25px;
             opacity:0.95;
+            margin:0;
         }
         .plan-card.featured .usage-period { color: var(--white); }
+
+        .pending-info{
+            margin:4px 0 0 0;
+            font-size:13px;
+            font-weight:800;
+            color:#ffeb3b;
+        }
+
+        .warning-text{
+            color: #ff5252;
+            font-size: 12px;
+            font-weight: 800;
+            margin-top: 5px;
+            background: rgba(255,255,255,0.9);
+            padding: 4px;
+            border-radius: 4px;
+            display: inline-block;
+        }
 
         .btn-plan{
             appearance:none; border:none; background:var(--primary); color:var(--white);
@@ -111,6 +148,8 @@
         <section class="title-section">
             <h1 class="title">요금제 안내</h1>
             <p class="desc">귀하의 비즈니스 성장에 딱 맞는 요금제를 선택하세요.</p>
+
+            <div id="creditInfo" style="margin-top: 20px;"></div>
         </section>
 
         <div class="plan-container" id="planList"></div>
@@ -120,21 +159,15 @@
 <script th:inline="javascript">
     const planListEl = document.getElementById('planList');
 
-    // SweetAlert2 기반 토스트 설정
-    const Toast = Swal.mixin({
-        toast: true,
-        position: 'bottom',
-        showConfirmButton: false,
-        timer: 3000,
-        timerProgressBar: true
-    });
-
     // 1. 초기 데이터 로드
     async function init() {
         try {
             const resMe = await fetch('/api/v1/company/subscription/me');
             const meJson = await resMe.json();
             const currentSub = meJson.data;
+
+            // 예치금 정보 렌더링
+            renderCreditInfo(currentSub.creditBalance);
 
             const resPlans = await fetch('/api/v1/subscriptions');
             const plansJson = await resPlans.json();
@@ -145,14 +178,46 @@
         }
     }
 
+    // 예치금 배지 렌더링 함수
+    function renderCreditInfo(balance) {
+        const el = document.getElementById('creditInfo');
+        if (balance > 0) {
+            el.innerHTML = `
+                <div class="credit-badge">
+                    <span>💰 보유 예치금: ₩${Math.round(balance).toLocaleString()}</span>
+                    <small style="font-size: 11px; opacity: 0.8; margin-left:5px;">(다음 결제 시 자동 공제됩니다)</small>
+                </div>
+            `;
+        } else {
+            el.innerHTML = '';
+        }
+    }
+
     // 2. 카드 렌더링 함수
     function renderPlans(plans, currentSub) {
         const currentSubNo = currentSub.subNo;
         const status = currentSub.status;
+        const pendingSubNo = currentSub.pendingSubNo;
+        const pendingSubName = currentSub.pendingSubName;
         const expiryDate = currentSub.nextBillingDate ? new Date(currentSub.nextBillingDate).toLocaleDateString() : null;
+        const empCnt = currentSub.empCnt || 0;
+        const pendingLimit = currentSub.pendingLimit || 30;
 
         planListEl.innerHTML = plans.map(plan => {
             const isCurrent = plan.subNo === currentSubNo;
+            const isPending = plan.subNo === pendingSubNo;
+            const name = plan.subName.toLowerCase();
+
+            // 요금제별 특화 기능 로직 추가 (9개 요금제 대응)
+            let specificFeatures = '';
+            if (name.includes('pro')) {
+                specificFeatures = `<li class="feature-item">챗봇기능 사용가능</li>`;
+            } else if (name.includes('ultimate')) {
+                specificFeatures = `
+                    <li class="feature-item">챗봇기능 사용가능</li>
+                    <li class="feature-item">회의 요약 기능 추가</li>
+                `;
+            }
 
             return `
                 <div class="plan-card ${isCurrent ? 'featured' : ''}">
@@ -163,21 +228,34 @@
                     </div>
 
                     <button class="btn-plan"
-                            onclick="handlePlanSelection(${plan.subNo})"
-                            ${isCurrent ? 'disabled' : ''}>
-                        ${isCurrent ? '현재 요금제' : '요금제 변경'}
+                            onclick="handlePlanSelection(${plan.subNo}, ${plan.subPrice})"
+                            ${isCurrent || isPending ? 'disabled' : ''}>
+                        ${isCurrent ? '현재 요금제' : (isPending ? '변경 예약됨' : '요금제 변경')}
                     </button>
 
                     ${isCurrent && expiryDate ? `
-                        <p class="usage-period">
-                            ${status === 'CANCELED' ? '만료 예정일: ' : '다음 결제일: '} ${expiryDate}
-                        </p>
+                        <div class="usage-info">
+                            <p class="usage-period">
+                                ${status === 'CANCELED' && !pendingSubName ? '만료 예정일: ' : '다음 결제일: '} ${expiryDate}
+                            </p>
+                            ${pendingSubName ? `
+                                <p class="pending-info">
+                                    ${expiryDate}부터 ${pendingSubName.toUpperCase()}로 전환 예약됨
+                                </p>
+                                ${empCnt > pendingLimit ? `
+                                    <div class="warning-text">⚠️ 주의: 현재 인원(${empCnt}명)이 예약 한도(${pendingLimit}명)를 초과합니다. 만료 전 조정하지 않으면 자동 연장됩니다.</div>
+                                ` : ''}
+                            ` : ''}
+                            ${status === 'CANCELED' && !pendingSubName && empCnt > 30 ? `
+                                <div class="warning-text">⚠️ 주의: 현재 인원(${empCnt}명)이 무료 한도(30명)를 초과합니다. 조정하지 않으면 해지가 취소됩니다.</div>
+                            ` : ''}
+                        </div>
                     ` : ''}
 
                     <div class="feature-title">주요 기능 :</div>
                     <ul class="feature-list">
                         <li class="feature-item">${plan.subDesc}</li>
-                        <li class="feature-item">모든 핵심 기능 포함</li>
+                        ${specificFeatures}
                         <li class="feature-item">연중무휴 기술 지원</li>
                     </ul>
                 </div>
@@ -186,25 +264,22 @@
     }
 
     // 3. 요금제 변경 로직 (SweetAlert2 적용)
-    async function handlePlanSelection(subNo) {
+    async function handlePlanSelection(subNo, subPrice) {
         let url = '';
         let method = '';
-        let title = '';
-        let text = '';
+        let title = '요금제 변경 확인';
+        let text = '보유하신 예치금이 있다면 결제 금액에서 최우선으로 차감됩니다.\n현재보다 낮은 요금제는 만료 후 전환되며, 높은 요금제(인원 확장 포함)는 즉시 차액 결제됩니다.';
 
         if (subNo === 1) { // 무료 요금제 선택 시 (해지 예약)
             url = '/api/v1/company/subscription/cancel';
             method = 'PATCH';
             title = '구독 해지 예약';
-            text = "무료 요금제로 변경하시겠습니까? 다음 결제가 중단되며 만료일까지 유료 혜택이 유지됩니다.";
-        } else { // 유료 요금제 선택 시 (업그레이드)
+            text = "무료 요금제로 변경하시겠습니까? 보유한 예치금은 다음 결제 시까지 보존되나, 만료일 이후 혜택이 제한됩니다.";
+        } else {
             url = `/api/v1/company/subscription/upgrade?subNo=${subNo}`;
             method = 'POST';
-            title = '요금제 업그레이드';
-            text = "해당 요금제로 변경하시겠습니까? 확인 시 즉시 결제가 진행됩니다.";
         }
 
-        // [SweetAlert2] 확인창 띄우기
         const result = await Swal.fire({
             title: title,
             text: text,
@@ -215,14 +290,19 @@
         });
 
         if (result.isConfirmed) {
-            Swal.showLoading(); // 처리 중 로딩 표시
+            Swal.showLoading();
             try {
                 const res = await fetch(url, { method: method });
                 const json = await res.json();
                 Swal.close();
 
                 if (res.ok) {
-                    await Swal.fire('처리 완료', '요금제 변경 요청이 정상적으로 처리되었습니다.', 'success');
+                    await Swal.fire({
+                        title: '처리 완료',
+                        text: '요금제 변경 요청이 정상적으로 처리되었습니다.',
+                        icon: 'success',
+                        confirmButtonText: '확인'
+                    });
                     location.reload();
                 } else {
                     Swal.fire('변경 실패', json.message || "오류가 발생했습니다.", 'error');


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용
- 요금제 변경 시 사원조건을 만료일까지 충족해야함을 표시
- 만료일에 사원조건 미충족 시 변경되지 않고 유지되도록 수정
- 요금제 다운그레이드 시 이번달까지는 더 비싼 요금제 유지되도록 수정
- 요금제 업그레이드 시 차감액만큼만 결제되도록 수정
- 요금제를 30인, 50, 100인 마다 Basic, Pro, Ultimate가 있도록 총 9개로 수정

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
