### PR TITLE
feat: 문서, 근태에 알림기능 추가. 근태, 결재문서 프론트 고도화

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/attendance/schedule/AttendanceSchedule.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/attendance/schedule/AttendanceSchedule.java
@@ -10,6 +10,8 @@ import com.multi.mlpenterpriseapprovalsystem.document.repository.ApprovalLineRep
 import com.multi.mlpenterpriseapprovalsystem.document.service.ApprovalLineService;
 import com.multi.mlpenterpriseapprovalsystem.employee.domain.Employee;
 import com.multi.mlpenterpriseapprovalsystem.employee.repository.EmployeeRepository;
+import com.multi.mlpenterpriseapprovalsystem.notification.domain.NotificationType;
+import com.multi.mlpenterpriseapprovalsystem.notification.service.NotificationService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -38,6 +40,7 @@ public class AttendanceSchedule {
     private final AttendanceRepository attendanceRepository;
     private final EmployeeRepository employeeRepository;
     private final ApprovalLineRepository approvalLineRepository;
+    private final NotificationService notificationService;
 
     @Scheduled(cron = "0 1 0 * * *")
     public void updateEmployeeDelegates() {
@@ -60,6 +63,17 @@ public class AttendanceSchedule {
                 onLeave.updateDelegate(null);
                 onLeave.updateAtteStatus("C");
 
+                // ✅ [알림] 대직 종료 알림
+                if (delegate != null) {
+                    notificationService.sendNotification(
+                            delegate,
+                            NotificationType.OTHER,
+                            "[대직 업무 종료]",
+                            onLeave.getEmpName() + "님의 복귀로 대직 업무가 종료되었습니다.",
+                            "/documents/me?status=PROCESSED" // 내가 처리한 문서함으로 이동
+                    );
+                }
+
                 log.info("근태 종료 처리: 사원={}, 기존대직자={}", onLeave.getEmpId(),
                         delegate != null ? delegate.getEmpId() : "없음");
             }
@@ -81,8 +95,26 @@ public class AttendanceSchedule {
         // [Step 3] 결재라인 대직자 투입 실행
         for (Attendance attendance : attendances) {
             if (attendance.getStartAt().toLocalDate().isEqual(today) && attendance.getType() == AtteType.V) {
-                if (attendance.getDelegate() != null) {
-                    addDelegateToApprovalLines(attendance.getEmployee(), attendance.getDelegate());
+//                if (attendance.getDelegate() != null) {
+//                    addDelegateToApprovalLines(attendance.getEmployee(), attendance.getDelegate());
+//                }
+
+                Employee onLeave = attendance.getEmployee();
+                Employee delegate = attendance.getDelegate();
+
+                if (delegate != null) {
+                    addDelegateToApprovalLines(onLeave, delegate);
+
+                    // ✅ [알림] 오늘부터 대직 업무 시작 알림
+                    notificationService.sendNotification(
+                            delegate,
+                            NotificationType.OTHER,
+                            "[대직 업무 시작]",
+                            "오늘부터 " + onLeave.getEmpName() + "님의 대직 업무가 시작됩니다. 결재할 문서를 확인해주세요.",
+                            "/documents/me?status=AWAITING" // 결재할 문서함으로 이동
+                    );
+
+                    log.info("대직 시작 알림 발송: 대직자={}", delegate.getEmpId());
                 }
             }
         }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/attendance/service/AttendanceService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/attendance/service/AttendanceService.java
@@ -14,6 +14,8 @@ import com.multi.mlpenterpriseapprovalsystem.company.domain.Company;
 import com.multi.mlpenterpriseapprovalsystem.document.domain.Document;
 import com.multi.mlpenterpriseapprovalsystem.employee.domain.Employee;
 import com.multi.mlpenterpriseapprovalsystem.employee.repository.EmployeeRepository;
+import com.multi.mlpenterpriseapprovalsystem.notification.domain.NotificationType;
+import com.multi.mlpenterpriseapprovalsystem.notification.service.NotificationService;
 import com.multi.mlpenterpriseapprovalsystem.organization.department.repository.DepartmentRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -44,16 +46,18 @@ public class AttendanceService {
     private final ObjectMapper objectMapper;
     private final AttendanceSchedule attendanceSchedule;
     private final DepartmentRepository departmentRepository;
+    private final NotificationService notificationService;
 
     public AttendanceService(AttendanceRepository attendanceRepository,
                              EmployeeRepository employeeRepository,
                              @Qualifier("objectMapper") ObjectMapper objectMapper,
-                             AttendanceSchedule attendanceSchedule, DepartmentRepository departmentRepository) {
+                             AttendanceSchedule attendanceSchedule, DepartmentRepository departmentRepository, NotificationService notificationService) {
         this.attendanceRepository = attendanceRepository;
         this.employeeRepository = employeeRepository;
         this.objectMapper = objectMapper;
         this.attendanceSchedule = attendanceSchedule;
         this.departmentRepository = departmentRepository;
+        this.notificationService = notificationService;
     }
 
     // 근태 식별자로 근태 조회
@@ -184,6 +188,11 @@ public class AttendanceService {
         attendanceRepository.save(attendance);
         document.linkAttendance(attendance); // 문서와 근태 연결 (이력 생성)
 
+        // ✅ 대직자 알림 추가
+        if (delegate != null) {
+            notifyDelegate(writer, delegate, document, "[대직 지정]", "님의 대직자로 지정되었습니다.");
+        }
+
         log.info("근태 등록 완료: empId={}, type={}, period={} ~ {}, days={}",
                 writer.getEmpId(), type, info.getStartAt(), info.getEndAt(), days);
 
@@ -304,6 +313,20 @@ public class AttendanceService {
         // 기존 근태 정보 수정
         targetAttendance.modifyDates(info.getStartAt(), info.getEndAt(), newDays); // 근태의 시간정보 갱신
         targetAttendance.updateRecentDocument(document); // 근태 엔티티의 '최근 문서' 필드도 현재의 수정 문서로 교체
+
+
+        // ✅ 대직자 변경 알림 추가
+        if (!java.util.Objects.equals(oldDelegate, newDelegate)) {
+            // 기존 대직자에게 해제 알림
+            if (oldDelegate != null) {
+                notifyDelegate(writer, oldDelegate, document, "[대직 해제]", "님의 대직 지정이 취소(변경)되었습니다.");
+            }
+            // 새 대직자에게 지정 알림
+            if (newDelegate != null) {
+                notifyDelegate(writer, newDelegate, document, "[대직 지정]", "님의 대직자로 지정되었습니다.");
+            }
+        }
+
         // 근태 엔티티의 대직자 정보도 새 대직자로 갱신해줘야 함!
         if (targetAttendance.getType() == AtteType.V) {
             targetAttendance.updateDelegate(newDelegate);
@@ -422,6 +445,11 @@ public class AttendanceService {
         Employee writer = document.getWriter();
         // 대직자
         Employee delegate = targetAttendance.getDelegate();
+
+        // ✅ 대직자 해제 알림 추가
+        if (delegate != null) {
+            notifyDelegate(writer, delegate, document, "[대직 해제]", "님의 근태 취소로 대직 지정이 해제되었습니다.");
+        }
 
         // 휴가이며, 대직자가 있고, 시작일이 오늘이면 결재라인에서 제거
         if(targetAttendance.getType() == AtteType.V && delegate != null && startDate.equals(today)) {
@@ -662,4 +690,19 @@ public class AttendanceService {
         return overlaps.stream().map(ResAttendanceDto::toDto).toList();
     }
 
+
+    /**
+     * 대직자에게 알림 전송 (지정/해제)
+     */
+    private void notifyDelegate(Employee writer, Employee delegate, Document document, String title, String messageSuffix) {
+        if (delegate == null) return;
+
+        notificationService.sendNotification(
+                delegate,
+                NotificationType.OTHER, // 또는 별도의 ATTENDANCE 타입이 있다면 사용
+                title,
+                writer.getEmpName() + " " + writer.getPositions().getPosName() + messageSuffix,
+                "/documents/" + document.getDocNo() + "?status=FINALIZED" // 최종 승인 문서 상세로 이동
+        );
+    }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document/dto/res/ResApprovalLineDto.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document/dto/res/ResApprovalLineDto.java
@@ -41,6 +41,9 @@ public class ResApprovalLineDto {
     @JsonProperty("isDelegate")
     private boolean isDelegate;
 
+    // ✅ 추가: 누구를 대신해서 결재했는지 표시할 이름
+    private String targetApproverName;
+
     public static ResApprovalLineDto toDto(ApprovalLine approvalLine) {
         return ResApprovalLineDto.builder()
                 .apprlNo(approvalLine.getApprlNo())
@@ -57,6 +60,9 @@ public class ResApprovalLineDto {
                 .endedAt(approvalLine.getEndedAt())
                 .isActualAppr(approvalLine.getIsActualAppr())
                 .rejReason(approvalLine.getRejReason())
+                // ✅ 추가: targetApprover가 존재할 경우 이름 매핑
+                .targetApproverName(approvalLine.getTargetApprover() != null ?
+                        approvalLine.getTargetApprover().getEmpName() : null)
                 .isDelegate(approvalLine.getIsDelegate())
                 .build();
     }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/document/service/DocumentService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/document/service/DocumentService.java
@@ -23,6 +23,8 @@ import com.multi.mlpenterpriseapprovalsystem.documentform.form.domain.DocumentFo
 import com.multi.mlpenterpriseapprovalsystem.documentform.form.domain.DocumentFormCategory;
 import com.multi.mlpenterpriseapprovalsystem.employee.domain.Employee;
 import com.multi.mlpenterpriseapprovalsystem.employee.repository.EmployeeRepository;
+import com.multi.mlpenterpriseapprovalsystem.notification.domain.NotificationType;
+import com.multi.mlpenterpriseapprovalsystem.notification.service.NotificationService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.domain.Page;
@@ -33,9 +35,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.time.LocalDateTime;
-import java.util.Comparator;
-import java.util.List;
-import java.util.OptionalInt;
+import java.util.*;
 
 /**
  * 문서 서비스 관리
@@ -58,6 +58,7 @@ public class DocumentService {
     private final DocumentOpenAiConfig documentOpenAiConfig;
     private final WebClient documentOpenAiWebClient;
     private final AttendanceService attendanceService;
+    private final NotificationService notificationService;
 
     public DocumentService(
             DocumentRepository documentRepository,
@@ -68,7 +69,7 @@ public class DocumentService {
             TempDocumentFormCategoryRepository tempDocumentFormCategoryRepository,
             DocumentOpenAiConfig documentOpenAiConfig,
             @Qualifier("documentOpenAiWebClient") WebClient documentOpenAiWebClient,
-            AttendanceService attendanceService
+            AttendanceService attendanceService, NotificationService notificationService
     ) {
         this.documentRepository = documentRepository;
         this.approvalLineRepository = approvalLineRepository;
@@ -79,6 +80,7 @@ public class DocumentService {
         this.documentOpenAiConfig = documentOpenAiConfig;
         this.documentOpenAiWebClient = documentOpenAiWebClient;
         this.attendanceService = attendanceService;
+        this.notificationService = notificationService;
     }
 
 
@@ -392,6 +394,10 @@ public class DocumentService {
             validateApproverNotSelf(myEmpId, reqDocumentDto.getApprovalLines());
             validateApprovalLineOrder(reqDocumentDto.getApprovalLines());
             createApprovalLines(document, company, reqDocumentDto.getApprovalLines(), isTemp);
+
+            if (!isTemp) {
+                notifyApprovers(document, 1); // 1번 순서 결재자들에게 알림
+            }
         }
 
         log.info("문서 {} 완료: docNo={}, writer={}", isTemp ? "임시저장" : "상신", document.getDocNo(), myEmpId);
@@ -447,152 +453,84 @@ public class DocumentService {
 
     // 결재라인 생성 (대직자 포함)
 //    private void createApprovalLines(Document document, Company company, List<ReqApprovalLineDto> lineDtos, boolean isTemp) {
-//
-//        // seq 기준 정렬하여 순서 보장
+//        // seq 기준 정렬
 //        List<ReqApprovalLineDto> sortedLines = lineDtos.stream()
 //                .sorted(Comparator.comparingInt(ReqApprovalLineDto::getSeq))
 //                .toList();
 //
-//        for (int i = 0; i < sortedLines.size(); i++) {
-//            ReqApprovalLineDto lineDto = sortedLines.get(i);
-//
-//            Employee approver = employeeRepository.findByEmpId(lineDto.getApproverId())
-//                    .orElseThrow(() -> new CustomException(ErrorCode.EMPLOYEE_NOT_FOUND));
-//
-//            // 첫 번째 결재자는 I(결재중), 나머지는 W(대기)
-//            ApprStat apprStat;
-//            if (isTemp) {
-//                apprStat = ApprStat.W;
-//            } else {
-//                apprStat = (i == 0) ? ApprStat.I : ApprStat.W;
-//            }
-//
-//            // 결재자 추가
-//            ApprovalLine approverLine = ApprovalLine.toEntity(
-//                    document,
-//                    approver,
-//                    company,
-//                    lineDto.getSeq(),
-//                    apprStat,
-//                    false,  // isDelegate = false
-//                    null
-//            );
-//            approvalLineRepository.save(approverLine);
-//
-//            // 결재자가 휴가중(V)이고 대직자가 있으면 대직자도 추가
-//            if ("V".equals(approver.getAtte()) && approver.getDelegate() != null) {
-//                ApprovalLine delegateLine = ApprovalLine.toEntity(
-//                        document,
-//                        approver.getDelegate(),
-//                        company,
-//                        lineDto.getSeq(),  // 같은 seq
-//                        apprStat,          // 같은 상태
-//                        true,               // isDelegate = true
-//                        approver
-//                );
-//                approvalLineRepository.save(delegateLine);
-//
-//                log.info("대직자 추가: 결재자={}, 대직자={}, seq={}",
-//                        approver.getEmpId(), approver.getDelegate().getEmpId(), lineDto.getSeq());
-//            }
-//        }
-//    }
-
-    // 결재라인 생성 (대직자 포함)
-//    private void createApprovalLines(Document document, Company company, List<ReqApprovalLineDto> lineDtos, boolean isTemp) {
-//        List<ReqApprovalLineDto> sortedLines = lineDtos.stream()
-//                .sorted(Comparator.comparingInt(ReqApprovalLineDto::getSeq))
-//                .toList();
+//        Employee writer = document.getWriter(); // ✅ 문서 작성자 정보
 //
 //        for (int i = 0; i < sortedLines.size(); i++) {
 //            ReqApprovalLineDto lineDto = sortedLines.get(i);
 //            Employee approver = employeeRepository.findByEmpId(lineDto.getApproverId())
 //                    .orElseThrow(() -> new CustomException(ErrorCode.EMPLOYEE_NOT_FOUND));
 //
+//            // 첫 결재자는 결재중(I), 나머지는 대기(W)
 //            ApprStat apprStat = isTemp ? ApprStat.W : (i == 0 ? ApprStat.I : ApprStat.W);
 //
-//            // 1. 원 결재자 추가 (A)
+//            // 1. 원 결재자 추가
 //            ApprovalLine approverLine = ApprovalLine.toEntity(
 //                    document, approver, company, lineDto.getSeq(), apprStat, false, null
 //            );
 //            approvalLineRepository.save(approverLine);
 //
-//            // 2. 연쇄 대직자 추적 및 추가 (A -> B -> C -> D)
+//            // 2. 대직자 체인 추적 및 추가
 //            Employee currentTarget = approver;
-//            // 현재 대상이 휴가 중(V)이고 대직자가 지정되어 있다면 계속 추적
+//
+//            // 현재 대상이 휴가 중(V)이고 대직자가 있다면 추적 시작
 //            while ("V".equals(currentTarget.getAtte()) && currentTarget.getDelegate() != null) {
 //                Employee delegate = currentTarget.getDelegate();
 //
-//                // 대직자 라인 생성 (targetApprover는 바로 직전 단계의 사람)
+//                // 대직자 라인 생성
 //                ApprovalLine delegateLine = ApprovalLine.toEntity(
 //                        document, delegate, company, lineDto.getSeq(), apprStat, true, currentTarget
 //                );
 //                approvalLineRepository.save(delegateLine);
 //
-//                log.info("연쇄 대직자 투입: {}의 대직자로 {} 지정 (seq: {})",
+//                log.info("문서 생성 시 대직자 투입: {}의 대직자 {} (seq: {})",
 //                        currentTarget.getEmpId(), delegate.getEmpId(), lineDto.getSeq());
 //
-//                // 다음 체인 확인을 위해 대상을 현재 대직자로 교체
+//                // 다음 체인 확인
 //                currentTarget = delegate;
-//
-//                // "휴가자는 대직자로 설정 불가" 규칙 덕분에 무한 루프에 빠지지 않고 결국 출근자에서 멈춤
 //            }
 //        }
+//    }
 
 
     private void createApprovalLines(Document document, Company company, List<ReqApprovalLineDto> lineDtos, boolean isTemp) {
-        // seq 기준 정렬
         List<ReqApprovalLineDto> sortedLines = lineDtos.stream()
                 .sorted(Comparator.comparingInt(ReqApprovalLineDto::getSeq))
                 .toList();
 
-        Employee writer = document.getWriter(); // ✅ 문서 작성자 정보
-
-        for (int i = 0; i < sortedLines.size(); i++) {
-            ReqApprovalLineDto lineDto = sortedLines.get(i);
+        for (ReqApprovalLineDto lineDto : sortedLines) {
             Employee approver = employeeRepository.findByEmpId(lineDto.getApproverId())
                     .orElseThrow(() -> new CustomException(ErrorCode.EMPLOYEE_NOT_FOUND));
 
-            // 첫 결재자는 결재중(I), 나머지는 대기(W)
-            ApprStat apprStat = isTemp ? ApprStat.W : (i == 0 ? ApprStat.I : ApprStat.W);
+            ApprStat apprStat = isTemp ? ApprStat.W : (lineDto.getSeq() == 1 ? ApprStat.I : ApprStat.W);
 
             // 1. 원 결재자 추가
-            ApprovalLine approverLine = ApprovalLine.toEntity(
-                    document, approver, company, lineDto.getSeq(), apprStat, false, null
-            );
+            ApprovalLine approverLine = ApprovalLine.toEntity(document, approver, company, lineDto.getSeq(), apprStat, false, null);
             approvalLineRepository.save(approverLine);
 
-            // 2. 대직자 체인 추적 및 추가
+            // 2. 대직자 체인 추적 (순환 참조 방지 로직 추가)
             Employee currentTarget = approver;
+            Set<String> visitedEmpIds = new HashSet<>();
+            visitedEmpIds.add(approver.getEmpId()); // 시작 결재자 기록
 
-            // 현재 대상이 휴가 중(V)이고 대직자가 있다면 추적 시작
             while ("V".equals(currentTarget.getAtte()) && currentTarget.getDelegate() != null) {
                 Employee delegate = currentTarget.getDelegate();
+                String delegateId = delegate.getEmpId();
 
-                // ✅ [핵심 추가]: 대직자가 문서 작성자 본인인지 체크
-//                if (delegate.getEmpId().equals(writer.getEmpId())) {
-//                    log.info("문서 생성 시 대직자가 작성자 본인이므로 제외: 문서={}, 사번={}",
-//                            document.getDocNo(), delegate.getEmpId());
-//
-//                    // 본인이라면 스킵하고, 이 대직자(나)도 휴가 중이라면 그다음 대직자를 찾음
-//                    if ("V".equals(delegate.getAtte()) && delegate.getDelegate() != null) {
-//                        currentTarget = delegate;
-//                        continue;
-//                    } else {
-//                        break; // 더 이상 대행할 사람이 없으면 종료
-//                    }
-//                }
+                // 순환 참조 확인
+                if (visitedEmpIds.contains(delegateId)) {
+                    log.error("대직자 순환 참조 감지: {} <-> {}", currentTarget.getEmpId(), delegateId);
+                    break; // 또는 비즈니스 로직에 따라 CustomException 발생
+                }
 
-                // 대직자 라인 생성
-                ApprovalLine delegateLine = ApprovalLine.toEntity(
-                        document, delegate, company, lineDto.getSeq(), apprStat, true, currentTarget
-                );
+                ApprovalLine delegateLine = ApprovalLine.toEntity(document, delegate, company, lineDto.getSeq(), apprStat, true, currentTarget);
                 approvalLineRepository.save(delegateLine);
 
-                log.info("문서 생성 시 대직자 투입: {}의 대직자 {} (seq: {})",
-                        currentTarget.getEmpId(), delegate.getEmpId(), lineDto.getSeq());
-
-                // 다음 체인 확인
+                visitedEmpIds.add(delegateId); // 방문 기록
                 currentTarget = delegate;
             }
         }
@@ -636,6 +574,9 @@ public class DocumentService {
         // 1. 문서 조회
         Document document = documentRepository.findById(docNo)
                 .orElseThrow(() -> new CustomException(ErrorCode.DOCUMENT_NOT_FOUND));
+
+        Employee currentApprover = employeeRepository.findByEmpId(myEmpId)
+                .orElseThrow(() -> new CustomException(ErrorCode.EMPLOYEE_NOT_FOUND));
 
         // 2. 회사 일치 확인
         if (!document.getCompany().getComId().equals(comId)) {
@@ -695,6 +636,9 @@ public class DocumentService {
 
                 // 문서양식이 휴가 신청서, 출장 신청서이면 호출
                 attendanceService.processAttendance(document);
+
+                notifyWriter(document, "[결재 승인]",
+                        currentApprover.getEmpName() + "님이 '" + document.getTitle() + "' 문서를 최종 승인하였습니다.");
             }
         } else if ("R".equals(apprStat)) {
             // 반려 처리
@@ -711,6 +655,8 @@ public class DocumentService {
 
             log.info("문서 반려: docNo={}, rejector={}, reason={}", docNo, myEmpId, reqDto.getRejReason());
 
+            notifyWriter(document, "[결재 반려]",
+                    currentApprover.getEmpName() + "님이 '" + document.getTitle() + "' 문서를 반려하였습니다. 사유: " + reqDto.getRejReason());
         } else {
             throw new CustomException(ErrorCode.INVALID_APPROVAL_STATUS);
         }
@@ -749,6 +695,10 @@ public class DocumentService {
             allLines.stream()
                     .filter(line -> line.getSeq() == nextSeq && line.getApprStat() == ApprStat.W)
                     .forEach(ApprovalLine::setInProgress);
+
+            // ✅ 다음 순번 결재자들에게 알림 발송
+            Document doc = allLines.get(0).getDocument();
+            notifyApprovers(doc, nextSeq);
         }
     }
 
@@ -1073,5 +1023,41 @@ public class DocumentService {
         documentRepository.delete(document);
 
         log.info("임시저장 문서 삭제 완료: docNo={}, writer={}", docNo, myEmpId);
+    }
+
+
+    /**
+     * 결재자들에게 결재 요청 알림 전송 (작성자 이름 포함)
+     */
+    private void notifyApprovers(Document document, int seq) {
+        String writerName = document.getWriter().getEmpName(); // 작성자 이름
+
+        List<ApprovalLine> approvers = approvalLineRepository.findByDocument_docNo(document.getDocNo())
+                .stream()
+                .filter(line -> line.getSeq() == seq)
+                .toList();
+
+        for (ApprovalLine line : approvers) {
+            notificationService.sendNotification(
+                    line.getApprover(),
+                    NotificationType.APPROVAL,
+                    "[결재 요청]",
+                    writerName + "님이 상신한 '" + document.getTitle() + "' 문서의 결재 차례입니다.",
+                    "/documents/" + document.getDocNo() + "?status=AWAITING"
+            );
+        }
+    }
+
+    /**
+     * 작성자에게 결재 결과 알림 전송 (결재자 이름 포함된 content를 인자로 받음)
+     */
+    private void notifyWriter(Document document, String title, String content) {
+        notificationService.sendNotification(
+                document.getWriter(),
+                NotificationType.APPROVAL,
+                title,
+                content,
+                "/documents/" + document.getDocNo() + "?status=SUBMITTED"
+        );
     }
 }

--- a/src/main/resources/templates/attendance/business-trip/list.html
+++ b/src/main/resources/templates/attendance/business-trip/list.html
@@ -29,6 +29,22 @@
 
             .page-title { font-size: 24px; font-weight: bold; color: #333; margin: 0; }
 
+            /* 출장 신청 버튼 스타일 */
+            .btn-apply {
+                background: #339af0;
+                color: white;
+                padding: 10px 18px;
+                border-radius: 6px;
+                border: none;
+                font-weight: bold;
+                font-size: 14px;
+                cursor: pointer;
+                transition: background 0.2s;
+            }
+            .btn-apply:hover {
+                background: #228be6;
+            }
+
             /* 테이블 공통 스타일 */
             .doc-table { width: 100%; border-collapse: collapse; table-layout: fixed; }
             .doc-table th { background-color: #f8f9fa; color: #495057; font-size: 14px; padding: 15px 12px; border-bottom: 1px solid #dee2e6; white-space: nowrap; }
@@ -74,6 +90,7 @@
             <div id="trip-container" class="detail-content-area">
                 <div class="page-header">
                     <h1 class="page-title">내 출장 관리</h1>
+                    <button class="btn-apply" onclick="goToTripApply()">출장 신청</button>
                 </div>
 
                 <div id="loading" class="loading">출장 정보를 불러오는 중...</div>
@@ -183,6 +200,14 @@
                 `;
                 tbody.appendChild(tr);
             });
+        }
+
+        function goToTripApply() {
+            if (!businessTripFormDocfoNo) {
+                alert('출장 신청서 양식을 불러오는 중입니다. 잠시 후 다시 시도해주세요.');
+                return;
+            }
+            location.href = `/documents/create?docfoNo=${businessTripFormDocfoNo}`;
         }
 
         // ✅ 수정 버튼 클릭 시

--- a/src/main/resources/templates/attendance/vacation/list.html
+++ b/src/main/resources/templates/attendance/vacation/list.html
@@ -29,6 +29,22 @@
 
             .page-title { font-size: 24px; font-weight: bold; color: #333; margin: 0; }
 
+            /* 휴가 신청 버튼 스타일 */
+            .btn-apply {
+                background: #339af0;
+                color: white;
+                padding: 10px 18px;
+                border-radius: 6px;
+                border: none;
+                font-weight: bold;
+                font-size: 14px;
+                cursor: pointer;
+                transition: background 0.2s;
+            }
+            .btn-apply:hover {
+                background: #228be6;
+            }
+
             /* 테이블 공통 스타일 */
             .doc-table { width: 100%; border-collapse: collapse; table-layout: fixed; }
             .doc-table th { background-color: #f8f9fa; color: #495057; font-size: 14px; padding: 15px 12px; border-bottom: 1px solid #dee2e6; white-space: nowrap; }
@@ -75,6 +91,7 @@
             <div id="vacation-container" class="detail-content-area">
                 <div class="page-header">
                     <h1 class="page-title">내 휴가 관리</h1>
+                    <button class="btn-apply" onclick="goToVacationApply()">휴가 신청</button>
                 </div>
 
                 <div id="loading" class="loading">휴가 정보를 불러오는 중...</div>
@@ -187,6 +204,14 @@
                 `;
                 tbody.appendChild(tr);
             });
+        }
+
+        function goToVacationApply() {
+            if (!vacationFormDocfoNo) {
+                alert('휴가 신청서 양식을 불러오는 중입니다. 잠시 후 다시 시도해주세요.');
+                return;
+            }
+            location.href = `/documents/create?docfoNo=${vacationFormDocfoNo}`;
         }
 
         function modifyVacation(atteNo) {

--- a/src/main/resources/templates/document/awaiting-detail.html
+++ b/src/main/resources/templates/document/awaiting-detail.html
@@ -347,7 +347,7 @@
             } catch (error) { showToast('다운로드 오류', 'error'); }
         }
 
-        /* ✅ 개선된 결재라인 렌더링 함수 */
+        /* ✅ 개선된 결재라인 렌더링 함수 (대직자 정보 포함) */
         function renderApprovalLine(lines) {
             const container = document.getElementById('approval-line');
             container.innerHTML = '';
@@ -360,18 +360,16 @@
                 lineBySeq[line.seq].push(line);
             });
 
-            // 2. 각 순번에서 보여줄 결재자 선별 (완료 시 실제결재자, 미완료 시 원결재자)
+            // 2. 각 순번에서 보여줄 결재자 선별
             const sortedSeqs = Object.keys(lineBySeq).sort((a, b) => a - b);
             const displayLines = [];
 
             sortedSeqs.forEach(seq => {
                 const stepLines = lineBySeq[seq];
-                // 실제 결재한 사람이 있는지 확인 (isActualAppr: true)
                 const actualApprover = stepLines.find(l => l.isActualAppr === true);
                 if (actualApprover) {
                     displayLines.push(actualApprover);
                 } else {
-                    // 완료되지 않았다면 대직자가 아닌 원결재자(!isDelegate)를 선택
                     const originalApprover = stepLines.find(l => !l.isDelegate);
                     if (originalApprover) displayLines.push(originalApprover);
                 }
@@ -382,8 +380,9 @@
                 const card = document.createElement('div');
                 card.className = 'approval-card ' + (line.apprStat === 'A' ? 'approved' : (line.apprStat === 'I' ? 'current' : (line.apprStat === 'R' ? 'rejected' : 'waiting')));
 
-                // 실제 결재자가 대직자인 경우 확인
-                const isDelegate = line.isDelegate && line.isActualAppr;
+                // ✅ 수정: 실제 결재자가 대직자인 경우 누구를 대신했는지 표시
+                const isDelegateAppr = line.isDelegate && line.isActualAppr;
+                const delegateLabel = isDelegateAppr ? `-대직(${line.targetApproverName || ''})-` : '';
 
                 card.innerHTML = `
                     <div class="approval-seq">결재자 ${line.seq}</div>
@@ -394,7 +393,7 @@
                         <div class="approval-pos">${line.approverPosName || ''}</div>
                     </div>
                     <div style="margin-top: auto; width: 100%;">
-                        ${isDelegate ? '<div style="font-size: 10px; color: #fa5252; font-weight: 700; margin-bottom: 4px;">-대직-</div>' : ''}
+                        ${isDelegateAppr ? `<div style="font-size: 10px; color: #fa5252; font-weight: 700; margin-bottom: 4px;">${delegateLabel}</div>` : ''}
                         <div class="approval-date" style="margin-top: 0; border-top: 1px solid #f1f3f5; padding-top: 8px;">
                             ${line.endedAt ? formatDateTimeInline(line.endedAt) : '-'}
                         </div>

--- a/src/main/resources/templates/document/create.html
+++ b/src/main/resources/templates/document/create.html
@@ -857,7 +857,9 @@
     let currentDocfoNo = null;
     let currentFormName = '';
     let tiptapEditor = null;
-    let attachedFiles = [];
+    let existingFiles = []; // ✅ 원본 문서의 첨부파일
+    let newFiles = []; // ✅ 새로 추가할 첨부파일
+    let filesToDelete = []; // ✅ 삭제할 파일 관리용 (여기서는 복사하지 않을 파일)
     let formCategories = [];
     let currentCategoryName = '';
     let myDelegatePeriods = []; // 내가 대직자인 기간 정보
@@ -1007,6 +1009,7 @@
         });
     }
 
+    // ✅ 수정/취소 진입 시 근태 정보를 불러오고 원본 문서의 상세 데이터를 보관하는 함수
     async function loadAttendanceInfo(atteNo, category) {
         try {
             const response = await fetch(`/api/v1/attendances/${atteNo}`, {
@@ -1047,17 +1050,110 @@
 
             window.targetAtteNo = atteNo;
 
+            // ✅ 원본 문서 데이터를 가져와서 보관 및 연동 (AI 요약, 첨부파일 포함)
+            if (attendance.docNo) {
+                const docResponse = await fetch(`/api/v1/documents/${attendance.docNo}?status=SUBMITTED`, {
+                    credentials: 'include'
+                });
+                const docResult = await docResponse.json();
+                if (docResult.data) {
+                    const doc = docResult.data;
+                    window.prevDocContentForPopulate = doc.content;
+
+                    // ✅ AI 요약 로드 추가
+                    if (doc.aiSumm && doc.aiSumm.trim() !== '') {
+                        const summaryBox = document.getElementById('ai-summary-box');
+                        const summaryText = document.getElementById('ai-summary-text');
+                        summaryBox.style.display = 'block';
+                        summaryText.innerText = doc.aiSumm;
+                        document.getElementById('include-ai-summ').checked = true;
+                    }
+
+                    // ✅ 첨부파일 목록 로드 호출
+                    await loadExistingAttachments(attendance.docNo);
+                }
+            }
+
             console.log('✅ 근태 정보 자동 입력 완료');
 
         } catch (error) {
             console.error('❌ 근태 정보 로드 실패:', error);
-            Swal.fire({
-                icon: 'error',
-                title: '오류 발생',
-                text: '근태 정보를 불러오는데 실패했습니다.',
-                confirmButtonColor: '#339af0'
-            });
         }
+    }
+
+    // ✅ 기존 첨부파일 목록 불러오기 함수
+    async function loadExistingAttachments(docNo) {
+        try {
+            const response = await fetch(`/api/v1/attachments?domain=APPROVAL&entityId=${docNo}`, { credentials: 'include' });
+            if (response.ok) {
+                const result = await response.json();
+                existingFiles = Array.isArray(result.data) ? result.data : (result.data?.items || []);
+                renderFileList();
+            }
+        } catch (e) {
+            console.error('❌ 기존 첨부파일 로드 실패:', e);
+        }
+    }
+
+    // ✅ 라벨 텍스트를 기반으로 원본 문서의 내용을 현재 에디터 표에 채우는 로직
+    function populateTableFromOriginalDoc(originalContent) {
+        if (!tiptapEditor || !originalContent) return;
+
+        let prevJson;
+        try {
+            prevJson = (typeof originalContent === 'string') ? JSON.parse(originalContent) : originalContent;
+        } catch (e) { return; }
+
+        const currentJson = tiptapEditor.getJSON();
+        const oldTable = findTableInContent(prevJson.content);
+        const newTable = findTableInContent(currentJson.content);
+
+        if (!oldTable || !newTable) return;
+
+        // 찾고자 하는 라벨 정의
+        const labels = ["휴가 구분", "출장지", "비상 연락처", "사유", "목적"];
+
+        // 셀 내부의 텍스트를 추출하는 헬퍼
+        function getCellText(cell) {
+            let text = "";
+            function walk(node) {
+                if (node.text) text += node.text;
+                if (node.content) node.content.forEach(walk);
+            }
+            if (cell.content) cell.content.forEach(walk);
+            return text.trim();
+        }
+
+        // 1. 원본 표에서 라벨 -> 내용 맵핑 생성
+        const valueMap = {};
+        oldTable.content.forEach(row => {
+            if (row.content) {
+                for (let i = 0; i < row.content.length; i++) {
+                    const cellText = getCellText(row.content[i]);
+                    const matchedLabel = labels.find(l => cellText === l);
+                    // 라벨을 찾았고, 다음 칸(Value)이 존재하는 경우
+                    if (matchedLabel && row.content[i + 1]) {
+                        valueMap[matchedLabel] = row.content[i + 1].content;
+                    }
+                }
+            }
+        });
+
+        // 2. 현재 새 에디터의 표 구조에 값 주입
+        newTable.content.forEach(row => {
+            if (row.content) {
+                for (let i = 0; i < row.content.length; i++) {
+                    const cellText = getCellText(row.content[i]);
+                    const matchedLabel = labels.find(l => cellText === l);
+                    if (matchedLabel && row.content[i + 1] && valueMap[matchedLabel]) {
+                        row.content[i + 1].content = valueMap[matchedLabel];
+                    }
+                }
+            }
+        });
+
+        tiptapEditor.commands.setContent(currentJson);
+        console.log('✅ 표 상세 내용(구분, 연락처, 사유/목적) 복사 완료');
     }
 
     function updateTableTargetAttendance(attendance) {
@@ -1843,6 +1939,12 @@
             },
             onSelectionUpdate: ({ editor }) => {
                 updateToolbarButtons();
+            },
+            // ✅ 에디터 로드 직후 수정 모드라면 표 내용 채우기 실행
+            onCreate: () => {
+                if (window.prevDocContentForPopulate) {
+                    populateTableFromOriginalDoc(window.prevDocContentForPopulate);
+                }
             }
         });
 
@@ -1856,6 +1958,7 @@
 
         updateCharCounter();
 
+        // 에디터 초기화 완료 후 수정/취소 시 데이터 주입
         if (window.targetAtteNo) {
             fetch(`/api/v1/attendances/${window.targetAtteNo}`, {
                 credentials: 'include'
@@ -2002,7 +2105,6 @@
         }).join('');
     }
 
-    // ✅ 대직자 본인 확인 후 추가 함수 (SweetAlert2 컨펌)
     function checkAndAddApprover(id, name, pos, dept, posOrder, delegateId) {
         if (delegateId === myInfo.empId) {
             Swal.fire({
@@ -2112,164 +2214,105 @@
         }
     }
 
+    // ✅ 파일 처리 로직 (상신 시 물리적 복사 포함)
     function handleFileSelect(event) {
         const files = Array.from(event.target.files);
         const maxSize = 10 * 1024 * 1024;
-        const maxCount = 5;
+        const currentCount = existingFiles.filter(f => !filesToDelete.includes(f.attachmentId)).length + newFiles.length;
 
         for (let file of files) {
-            if (attachedFiles.length >= maxCount) {
-                Swal.fire({
-                    icon: 'warning',
-                    title: '첨부 제한',
-                    text: `최대 ${maxCount}개까지만 첨부할 수 있습니다.`,
-                    confirmButtonColor: '#339af0'
-                });
+            if (currentCount + newFiles.length >= 5) {
+                Swal.fire({ icon: 'warning', title: '제한', text: '최대 5개입니다.' });
                 break;
             }
             if (file.size > maxSize) {
-                Swal.fire({
-                    icon: 'warning',
-                    title: '파일 크기 초과',
-                    text: `${file.name}은(는) 10MB를 초과합니다.`,
-                    confirmButtonColor: '#339af0'
-                });
+                Swal.fire({ icon: 'warning', title: '파일 크기 초과', text: `${file.name}은(는) 10MB를 초과합니다.` });
                 continue;
             }
-            if (attachedFiles.some(f => f.name === file.name && f.size === file.size)) {
-                Swal.fire({
-                    icon: 'info',
-                    title: '중복 파일',
-                    text: `${file.name}은(는) 이미 첨부되었습니다.`,
-                    confirmButtonColor: '#339af0'
-                });
-                continue;
-            }
-            attachedFiles.push(file);
+            newFiles.push(file);
         }
-        event.target.value = '';
         renderFileList();
     }
 
     function renderFileList() {
         const container = document.getElementById('file-list');
-        if (attachedFiles.length === 0) {
+        const activeExisting = existingFiles.filter(f => !filesToDelete.includes(f.attachmentId));
+        if (activeExisting.length + newFiles.length === 0) {
             container.innerHTML = '<div style="color: #adb5bd; font-size: 12px; padding: 10px;">첨부된 파일이 없습니다.</div>';
             return;
         }
-        container.innerHTML = attachedFiles.map((file, index) => `
-            <div class="file-item">
+
+        let html = activeExisting.map(file => `
+            <div class="file-item" style="background: #f0f8ff;">
                 <div class="file-item-info">
-                    <span style="font-size: 18px;">📄</span>
+                    <span>📄</span>
                     <div>
-                        <div class="file-item-name">${file.name}</div>
-                        <div class="file-item-size">${formatFileSize(file.size)}</div>
+                        <div class="file-item-name">${file.originalName}</div>
+                        <div class="file-item-size">${formatFileSize(file.size)} <span style="color: #339af0;">(기존)</span></div>
                     </div>
                 </div>
-                <span class="file-remove-btn" onclick="removeFile(${index})">✕</span>
-            </div>
-        `).join('');
+                <span class="file-remove-btn" onclick="removeExistingFile(${file.attachmentId})">✕</span>
+            </div>`).join('');
+
+        html += newFiles.map((file, index) => `
+            <div class="file-item">
+                <div class="file-item-info">
+                    <span>📄</span>
+                    <div>
+                        <div class="file-item-name">${file.name}</div>
+                        <div class="file-item-size">${formatFileSize(file.size)} <span style="color: #40c057;">(새 파일)</span></div>
+                    </div>
+                </div>
+                <span class="file-remove-btn" onclick="removeNewFile(${index})">✕</span>
+            </div>`).join('');
+
+        container.innerHTML = html;
     }
 
-    function removeFile(index) {
-        attachedFiles.splice(index, 1);
-        renderFileList();
-    }
+    function removeExistingFile(id) { filesToDelete.push(id); renderFileList(); }
+    function removeNewFile(index) { newFiles.splice(index, 1); renderFileList(); }
 
     function formatFileSize(bytes) {
         if (bytes === 0) return '0 Bytes';
         const k = 1024;
-        const sizes = ['Bytes', 'KB', 'MB', 'GB'];
         const i = Math.floor(Math.log(bytes) / Math.log(k));
-        return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + sizes[i];
+        return Math.round(bytes / Math.pow(k, i) * 100) / 100 + ' ' + ['Bytes', 'KB', 'MB', 'GB'][i];
     }
 
-    function getFileType(mimeType) {
-        if (mimeType.startsWith('image/')) return 'IMAGE';
-        if (mimeType.startsWith('audio/')) return 'AUDIO';
-        return 'DOC';
+    function getFileType(mime) { return mime.startsWith('image/') ? 'IMAGE' : (mime.startsWith('audio/') ? 'AUDIO' : 'DOC'); }
+
+    async function generateAiSummary() {
+        const summaryBox = document.getElementById('ai-summary-box');
+        const summaryText = document.getElementById('ai-summary-text');
+        summaryBox.style.display = 'block';
+        summaryText.innerText = '⏳ 생성 중...';
+        try {
+            const response = await fetch('/api/v1/documents/ai-summary', {
+                method: 'POST',
+                credentials: 'include',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: tiptapEditor.getHTML() })
+            });
+            const result = await response.json();
+            if (result.data) summaryText.innerText = result.data;
+        } catch (error) {
+            summaryBox.style.display = 'none';
+        }
     }
 
     async function saveDocument(isTemp) {
         const title = document.getElementById('doc-title').value.trim();
         const contentJson = tiptapEditor.getJSON();
-        const contentHtml = tiptapEditor.getHTML();
-        const contentText = tiptapEditor.getText().trim();
         const checkedRadio = document.querySelector('input[name="docfoCatNo"]:checked');
-
-        let startDate = null;
-        let endDate = null;
-
         const normalized = currentCategoryName.replace(/\s+/g, '').toLowerCase();
-        const isAttendanceCategory = normalized.includes('휴가') || normalized.includes('출장');
 
-        if (isAttendanceCategory) {
-            startDate = document.getElementById('startDate').value;
-            endDate = document.getElementById('endDate').value;
+        if (!title || !checkedRadio) return;
 
-            if (!isTemp) {
-                if (!startDate || !endDate) {
-                    return Swal.fire({
-                        icon: 'warning',
-                        title: '입력 오류',
-                        text: '시작일과 종료일을 입력해주세요.',
-                        confirmButtonColor: '#339af0'
-                    });
-                }
-                if (startDate > endDate) {
-                    return Swal.fire({
-                        icon: 'warning',
-                        title: '입력 오류',
-                        text: '종료일이 시작일보다 빠를 수 없습니다.',
-                        confirmButtonColor: '#339af0'
-                    });
-                }
-            }
-
-            contentJson.attendanceInfo = {
-                startDate: startDate,
-                endDate: endDate
-            };
-
-            if (window.targetAtteNo) {
-                contentJson.attendanceInfo.targetAtteNo = window.targetAtteNo;
-            }
-
-            if ((normalized === '휴가신청' || normalized === '휴가수정신청') && selectedDelegate) {
-                contentJson.attendanceInfo.delegate = {
-                    empId: selectedDelegate.empId,
-                    empName: selectedDelegate.empName,
-                    posName: selectedDelegate.posName,
-                    depName: selectedDelegate.depName
-                };
-            }
-        }
-
-        if (!title || !contentText) {
-            return Swal.fire({
-                icon: 'warning',
-                title: '입력 오류',
-                text: '제목과 내용을 모두 입력해주세요.',
-                confirmButtonColor: '#339af0'
-            });
-        }
-
-        if (!checkedRadio) {
-            return Swal.fire({
-                icon: 'warning',
-                title: '입력 오류',
-                text: '카테고리를 선택해주세요.',
-                confirmButtonColor: '#339af0'
-            });
-        }
-
-        if (!isTemp && selectedApprovers.length === 0) {
-            return Swal.fire({
-                icon: 'warning',
-                title: '입력 오류',
-                text: '문서를 상신하려면 결재선을 최소 1명 이상 지정해야 합니다.',
-                confirmButtonColor: '#339af0'
-            });
+        if (normalized.includes('휴가') || normalized.includes('출장')) {
+            const start = document.getElementById('startDate').value;
+            const end = document.getElementById('endDate').value;
+            contentJson.attendanceInfo = { startDate: start, endDate: end, targetAtteNo: window.targetAtteNo };
+            if (selectedDelegate) contentJson.attendanceInfo.delegate = { empId: selectedDelegate.empId, empName: selectedDelegate.empName };
         }
 
         try {
@@ -2280,9 +2323,9 @@
                 docfoCatNo: parseInt(checkedRadio.value, 10),
                 title: title,
                 content: JSON.stringify(contentJson),
-                cnttHtml: contentHtml,
+                cnttHtml: tiptapEditor.getHTML(),
                 temp: isTemp,
-                aiSumm: document.getElementById('include-ai-summ').checked ? document.getElementById('ai-summary-text').innerText : null,
+                aiSumm: document.getElementById('ai-summary-text').innerText,
                 approvalLines: selectedApprovers.map((a, i) => ({
                     approverId: a.approverId,
                     seq: i + 1,
@@ -2301,153 +2344,70 @@
                 const result = await response.json();
                 const docNo = result.data?.docNo || result.data;
 
-                if (attachedFiles.length > 0 && docNo) {
-                    await uploadFiles(docNo);
-                }
+                // ✅ 기존 파일 복사 (물리적 업로드)
+                const activeExisting = existingFiles.filter(f => !filesToDelete.includes(f.attachmentId));
+                if (activeExisting.length > 0) await copyExistingFiles(activeExisting, docNo);
 
-                if ((normalized === '휴가신청' || normalized === '휴가수정신청') && selectedDelegate && docNo) {
-                    await registerDelegate(docNo, selectedDelegate.empId);
-                }
+                // ✅ 신규 파일 업로드
+                if (newFiles.length > 0) await uploadFiles(docNo);
 
-                const successMessage = isTemp ? "임시 저장되었습니다." : "문서가 상신되었습니다.";
-                const targetUrl = isTemp ? "/documents/me?status=UNSUBMITTED" : "/documents/me?status=SUBMITTED";
-
-                Swal.fire({
-                    icon: 'success',
-                    title: '완료',
-                    text: successMessage,
-                    confirmButtonColor: '#339af0'
-                }).then(() => {
-                    location.href = targetUrl;
-                });
-            } else {
-                const err = await response.json().catch(() => ({}));
-                Swal.fire({
-                    icon: 'error',
-                    title: '오류 발생',
-                    text: err.message || "문서 처리에 실패했습니다.",
-                    confirmButtonColor: '#339af0'
+                Swal.fire({ icon: 'success', title: '완료' }).then(() => {
+                    location.href = isTemp ? "/documents/me?status=UNSUBMITTED" : "/documents/me?status=SUBMITTED";
                 });
             }
-        } catch (e) {
-            Swal.fire({
-                icon: 'error',
-                title: '통신 오류',
-                text: '서버와의 통신에 실패했습니다.\n잠시 후 다시 시도해주세요.',
-                confirmButtonColor: '#339af0'
-            });
-        }
+        } catch (e) {}
     }
 
-    async function registerDelegate(docNo, delegateEmpId) {
-        try {
-            const response = await fetch('/api/v1/delegates', {
-                method: 'POST',
-                credentials: 'include',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ docNo: docNo, delegateEmpId: delegateEmpId })
-            });
-            if (response.ok) {
-                console.log('✅ 대직자 등록 성공');
-            }
-        } catch (e) {
-            console.warn('⚠️ 대직자 등록 실패:', e);
-        }
-    }
-
-    async function uploadFiles(docNo) {
-        for (const file of attachedFiles) {
+    async function copyExistingFiles(files, newDocNo) {
+        for (const file of files) {
             try {
-                const presignRes = await fetch('/api/v1/attachments/presign', {
+                const resUrl = await fetch(`/api/v1/attachments/${file.attachmentId}/download-url`, { credentials: 'include' });
+                const dataUrl = await resUrl.json();
+                const blob = await (await fetch(dataUrl.data.url)).blob();
+
+                const presign = await fetch('/api/v1/attachments/presign', {
                     method: 'POST',
                     credentials: 'include',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        domain: 'APPROVAL',
-                        entityId: docNo,
-                        fileType: getFileType(file.type),
-                        originalName: file.name,
-                        contentType: file.type,
-                        size: file.size
+                        domain: 'APPROVAL', entityId: newDocNo, fileType: file.fileType,
+                        originalName: file.originalName, contentType: file.contentType, size: file.size
                     })
                 });
-
-                if (!presignRes.ok) continue;
-                const presignData = await presignRes.json();
-                const { objectKey, uploadUrl } = presignData.data;
-
-                const uploadRes = await fetch(uploadUrl, {
-                    method: 'PUT',
-                    headers: { 'Content-Type': file.type },
-                    body: file
-                });
-
-                if (!uploadRes.ok) continue;
-                const etag = uploadRes.headers.get('ETag');
-
+                const presignData = await presign.json();
+                const upload = await fetch(presignData.data.uploadUrl, { method: 'PUT', headers: { 'Content-Type': file.contentType }, body: blob });
                 await fetch('/api/v1/attachments/complete', {
                     method: 'POST',
                     credentials: 'include',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        domain: 'APPROVAL',
-                        entityId: docNo,
-                        fileType: getFileType(file.type),
-                        objectKey: objectKey,
-                        originalName: file.name,
-                        contentType: file.type,
-                        size: file.size,
-                        etag: etag ? etag.replace(/"/g, '') : null
+                        domain: 'APPROVAL', entityId: newDocNo, fileType: file.fileType,
+                        objectKey: presignData.data.objectKey, originalName: file.originalName,
+                        contentType: file.contentType, size: file.size, etag: upload.headers.get('ETag')?.replace(/"/g, '')
                     })
                 });
-            } catch (e) {
-                console.error('파일 업로드 오류:', e);
-            }
+            } catch (e) { console.error('기존 파일 복사 오류', e); }
         }
     }
 
-    async function generateAiSummary() {
-        const html = tiptapEditor.getHTML();
-        const text = tiptapEditor.getText().trim();
-
-        if (text.length < 100) {
-            return Swal.fire({
-                icon: 'warning',
-                title: 'AI 요약 오류',
-                text: '내용이 너무 짧아 요약할 수 없습니다.\n최소 100자 이상 입력해주세요.',
-                confirmButtonColor: '#339af0'
-            });
-        }
-
-        const summaryBox = document.getElementById('ai-summary-box');
-        const summaryText = document.getElementById('ai-summary-text');
-        summaryBox.style.display = 'block';
-        summaryText.innerHTML = '<span style="color:#868e96;">⏳ AI 요약 생성 중...</span>';
-
-        try {
-            const response = await fetch('/api/v1/documents/ai-summary', {
-                method: 'POST',
-                credentials: 'include',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ content: html })
-            });
-
-            if (!response.ok) throw new Error('AI 요약 생성 실패');
-            const result = await response.json();
-
-            if (result.data) {
-                summaryText.innerText = result.data;
-            } else {
-                throw new Error('요약 데이터가 없습니다');
-            }
-        } catch (error) {
-            summaryBox.style.display = 'none';
-            Swal.fire({
-                icon: 'error',
-                title: 'AI 요약 실패',
-                text: 'AI 요약 생성에 실패했습니다.\n잠시 후 다시 시도해주세요.',
-                confirmButtonColor: '#339af0'
-            });
+    async function uploadFiles(docNo) {
+        for (const file of newFiles) {
+            try {
+                const presign = await fetch('/api/v1/attachments/presign', {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ domain: 'APPROVAL', entityId: docNo, fileType: getFileType(file.type), originalName: file.name, contentType: file.type, size: file.size })
+                });
+                const presignData = await presign.json();
+                const upload = await fetch(presignData.data.uploadUrl, { method: 'PUT', headers: { 'Content-Type': file.type }, body: file });
+                await fetch('/api/v1/attachments/complete', {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ domain: 'APPROVAL', entityId: docNo, fileType: getFileType(file.type), objectKey: presignData.data.objectKey, originalName: file.name, contentType: file.type, size: file.size, etag: upload.headers.get('ETag')?.replace(/"/g, '') })
+                });
+            } catch (e) {}
         }
     }
 </script>

--- a/src/main/resources/templates/document/finalized-detail.html
+++ b/src/main/resources/templates/document/finalized-detail.html
@@ -128,10 +128,10 @@
 
             .loading { text-align: center; padding: 100px; color: #868e96; font-size: 16px; }
 
-            /* ✅ 레이아웃 상속 시 콘텐츠 영역 배경 및 패딩 정의 (결재할 문서와 동일하게 수정) */
+            /* ✅ 레이아웃 상속 시 콘텐츠 영역 배경 및 패딩 정의 */
             .page-with-subbar > div:last-child {
                 background: #f6f7fb;
-                padding: 22px 26px; /* 👈 목록 페이지 여백과 동일하게 설정 */
+                padding: 22px 26px;
             }
         </style>
     </th:block>
@@ -297,7 +297,7 @@
             } catch (error) { alert('다운로드 중 오류 발생'); }
         }
 
-        /* ✅ 개선된 결재라인 렌더링 함수 */
+        /* ✅ 개선된 결재라인 렌더링 함수 (대직자 정보 포함) */
         function renderApprovalLine(lines) {
             const container = document.getElementById('approval-line');
             container.innerHTML = '';
@@ -310,18 +310,16 @@
                 lineBySeq[line.seq].push(line);
             });
 
-            // 2. 각 순번에서 보여줄 결재자 선별 (완료 시 실제결재자, 미완료 시 원결재자)
+            // 2. 각 순번에서 보여줄 결재자 선별
             const sortedSeqs = Object.keys(lineBySeq).sort((a, b) => a - b);
             const displayLines = [];
 
             sortedSeqs.forEach(seq => {
                 const stepLines = lineBySeq[seq];
-                // 실제 결재한 사람이 있는지 확인 (isActualAppr: true)
                 const actualApprover = stepLines.find(l => l.isActualAppr === true);
                 if (actualApprover) {
                     displayLines.push(actualApprover);
                 } else {
-                    // 완료되지 않았다면 대직자가 아닌 원결재자(!isDelegate)를 선택
                     const originalApprover = stepLines.find(l => !l.isDelegate);
                     if (originalApprover) displayLines.push(originalApprover);
                 }
@@ -332,8 +330,9 @@
                 const card = document.createElement('div');
                 card.className = 'approval-card ' + (line.apprStat === 'A' ? 'approved' : (line.apprStat === 'I' ? 'current' : (line.apprStat === 'R' ? 'rejected' : 'waiting')));
 
-                // 실제 결재자가 대직자인 경우 확인
-                const isDelegate = line.isDelegate && line.isActualAppr;
+                // ✅ 수정: 실제 결재자가 대직자인 경우 누구를 대신했는지 표시
+                const isDelegateAppr = line.isDelegate && line.isActualAppr;
+                const delegateLabel = isDelegateAppr ? `-대직(${line.targetApproverName || ''})-` : '';
 
                 card.innerHTML = `
                     <div class="approval-seq">결재자 ${line.seq}</div>
@@ -344,7 +343,7 @@
                         <div class="approval-pos">${line.approverPosName || ''}</div>
                     </div>
                     <div style="margin-top: auto; width: 100%;">
-                        ${isDelegate ? '<div style="font-size: 10px; color: #fa5252; font-weight: 700; margin-bottom: 4px;">-대직-</div>' : ''}
+                        ${isDelegateAppr ? `<div style="font-size: 10px; color: #fa5252; font-weight: 700; margin-bottom: 4px;">${delegateLabel}</div>` : ''}
                         <div class="approval-date" style="margin-top: 0; border-top: 1px solid #f1f3f5; padding-top: 8px;">
                             ${line.endedAt ? formatDateTimeInline(line.endedAt) : '-'}
                         </div>

--- a/src/main/resources/templates/document/processed-detail.html
+++ b/src/main/resources/templates/document/processed-detail.html
@@ -11,7 +11,7 @@
         <script th:src="@{/js/jiheon-temp-origin/tiptap.min.js}"></script>
 
         <style>
-            /* ✅ 여백 최적화: 고정 너비(1100px)를 해제하여 화면에 가득 차게 설정 */
+            /* ✅ 여백 최적화: 고정 너비를 해제하여 화면에 가득 차게 설정 */
             .detail-content-area {
                 background: white;
                 padding: 40px;
@@ -52,7 +52,7 @@
             .info-value { font-size: 14px; color: #333; font-weight: 500; }
             .doc-id { font-size: 15px; font-weight: bold; color: #339af0; }
 
-            /* ✅ 개선된 결재라인 디자인 */
+            /* 결재라인 디자인 */
             .approval-section-title {
                 font-size: 14px; font-weight: 600; color: #495057; margin-bottom: 12px;
                 padding-left: 10px; border-left: 3px solid #339af0;
@@ -131,7 +131,7 @@
 
             .loading { text-align: center; padding: 100px; color: #868e96; font-size: 16px; }
 
-            /* ✅ 레이아웃 상속 시 패딩 정의 (목록 페이지와 일치) */
+            /* 레이아웃 상속 시 패딩 정의 */
             .page-with-subbar > div:last-child { background: #f6f7fb; padding: 22px 26px; }
 
             /* 버튼 그룹 */
@@ -290,7 +290,7 @@
             } catch (error) { console.error('파일 다운로드 오류', error); }
         }
 
-        /* ✅ 개선된 결재라인 렌더링 함수 */
+        /* ✅ 개선된 결재라인 렌더링 함수 (대직자 정보 포함) */
         function renderApprovalLine(lines) {
             const container = document.getElementById('approval-line');
             container.innerHTML = '';
@@ -303,18 +303,16 @@
                 lineBySeq[line.seq].push(line);
             });
 
-            // 2. 각 순번에서 보여줄 결재자 선별 (완료 시 실제결재자, 미완료 시 원결재자)
+            // 2. 각 순번에서 보여줄 결재자 선별
             const sortedSeqs = Object.keys(lineBySeq).sort((a, b) => a - b);
             const displayLines = [];
 
             sortedSeqs.forEach(seq => {
                 const stepLines = lineBySeq[seq];
-                // 실제 결재한 사람이 있는지 확인 (isActualAppr: true)
                 const actualApprover = stepLines.find(l => l.isActualAppr === true);
                 if (actualApprover) {
                     displayLines.push(actualApprover);
                 } else {
-                    // 완료되지 않았다면 대직자가 아닌 원결재자(!isDelegate)를 선택
                     const originalApprover = stepLines.find(l => !l.isDelegate);
                     if (originalApprover) displayLines.push(originalApprover);
                 }
@@ -325,8 +323,9 @@
                 const card = document.createElement('div');
                 card.className = 'approval-card ' + (line.apprStat === 'A' ? 'approved' : (line.apprStat === 'I' ? 'current' : (line.apprStat === 'R' ? 'rejected' : 'waiting')));
 
-                // 실제 결재자가 대직자인 경우 확인
-                const isDelegate = line.isDelegate && line.isActualAppr;
+                // ✅ 수정: 실제 결재자가 대직자인 경우 누구를 대신했는지 표시
+                const isDelegateAppr = line.isDelegate && line.isActualAppr;
+                const delegateLabel = isDelegateAppr ? `-대직(${line.targetApproverName || ''})-` : '';
 
                 card.innerHTML = `
                     <div class="approval-seq">결재자 ${line.seq}</div>
@@ -337,7 +336,7 @@
                         <div class="approval-pos">${line.approverPosName || ''}</div>
                     </div>
                     <div style="margin-top: auto; width: 100%;">
-                        ${isDelegate ? '<div style="font-size: 10px; color: #fa5252; font-weight: 700; margin-bottom: 4px;">-대직-</div>' : ''}
+                        ${isDelegateAppr ? `<div style="font-size: 10px; color: #fa5252; font-weight: 700; margin-bottom: 4px;">${delegateLabel}</div>` : ''}
                         <div class="approval-date" style="margin-top: 0; border-top: 1px solid #f1f3f5; padding-top: 8px;">
                             ${line.endedAt ? formatDateTimeInline(line.endedAt) : '-'}
                         </div>

--- a/src/main/resources/templates/document/submitted-detail.html
+++ b/src/main/resources/templates/document/submitted-detail.html
@@ -11,7 +11,7 @@
         <script th:src="@{/js/jiheon-temp-origin/tiptap.min.js}"></script>
 
         <style>
-            /* ✅ 여백 최적화: 고정 너비를 해제하고 결재할 문서 상세와 동일하게 설정 */
+            /* ✅ 여백 최적화 */
             .detail-content-area {
                 background: white;
                 padding: 40px;
@@ -70,7 +70,7 @@
             .info-value { font-size: 14px; color: #333; font-weight: 500; }
             .doc-id { font-size: 15px; font-weight: bold; color: #339af0; }
 
-            /* ✅ 결재라인 디자인 개선 */
+            /* 결재라인 디자인 */
             .approval-section-title { font-size: 14px; font-weight: 600; color: #495057; margin-bottom: 12px; padding-left: 10px; border-left: 3px solid #339af0; }
             .approval-card-container { display: flex; gap: 10px; flex-wrap: nowrap; align-items: stretch; }
             .approval-card {
@@ -127,7 +127,7 @@
             .file-item:hover { background: #e7f5ff; border-color: #339af0; transform: translateY(-2px); }
             .file-name { font-size: 13px; font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; width: 100%; text-align: center; }
 
-            /* ✅ 개편된 심플 반려 정보 (결재한 문서 상세와 동일) */
+            /* 반려 정보 */
             .reject-card { background: linear-gradient(135deg, #fff5f5 0%, #fff 100%); border: 1px solid #ffc9c9; border-radius: 10px; padding: 20px; }
             .reject-reason-box { background: #fff; border: 1px solid #ffc9c9; border-radius: 6px; padding: 15px; font-size: 14px; color: #333; min-height: 60px; }
 
@@ -137,7 +137,7 @@
 
             .loading { text-align: center; padding: 100px; color: #868e96; font-size: 16px; }
 
-            /* ✅ 레이아웃 상속 시 패딩 정의 (결재할 문서와 동일) */
+            /* 레이아웃 상속 패딩 */
             .page-with-subbar > div:last-child { background: #f6f7fb; padding: 22px 26px; }
 
             /* 모달 및 토스트 */
@@ -362,8 +362,9 @@
                 const card = document.createElement('div');
                 card.className = 'approval-card ' + (line.apprStat === 'A' ? 'approved' : (line.apprStat === 'I' ? 'current' : (line.apprStat === 'R' ? 'rejected' : 'waiting')));
 
-                // 실제 결재자가 대직자인 경우 확인
-                const isDelegate = line.isDelegate && line.isActualAppr;
+                // ✅ 수정: 실제 결재자가 대직자인 경우 누구를 대신했는지 표시
+                const isDelegateAppr = line.isDelegate && line.isActualAppr;
+                const delegateLabel = isDelegateAppr ? `-대직(${line.targetApproverName || ''})-` : '';
 
                 card.innerHTML = `
                     <div class="approval-seq">결재자 ${line.seq}</div>
@@ -374,7 +375,7 @@
                         <div class="approval-pos">${line.approverPosName || ''}</div>
                     </div>
                     <div style="margin-top: auto; width: 100%;">
-                        ${isDelegate ? '<div style="font-size: 10px; color: #fa5252; font-weight: 700; margin-bottom: 4px;">-대직-</div>' : ''}
+                        ${isDelegateAppr ? `<div style="font-size: 10px; color: #fa5252; font-weight: 700; margin-bottom: 4px;">${delegateLabel}</div>` : ''}
                         <div class="approval-date" style="margin-top: 0; border-top: 1px solid #f1f3f5; padding-top: 8px;">
                             ${line.endedAt ? formatDateTimeInline(line.endedAt) : '-'}
                         </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용
- 문서, 근태에 알림기능 추가
- 대직자 표시 시 누구의 대직자인지도 함께 표시
- 내 휴가, 출장 관리 화면에 신청버튼 추가
- 휴가/출장 수정, 취소 때 기존 정보 표시하도록 수정

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
