### PR TITLE
feat : fastapi와 http 통신 실패시 상태값에 실패 들어가게 기능 추가 

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/client/EmbeddingClient.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/client/EmbeddingClient.java
@@ -13,6 +13,8 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.Duration;
+
 /**
  * 임베딩 요청 클라이언트
  *
@@ -63,6 +65,6 @@ public class EmbeddingClient {
                                 .map(body -> new CustomException(ErrorCode.EMBEDDING_DELETE_FAILED))
                 )
                 .toBodilessEntity()
-                .block();
+                .block(Duration.ofSeconds(10));
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/client/MeetingAiClient.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/client/MeetingAiClient.java
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -50,7 +51,6 @@ public class MeetingAiClient {
                 .retrieve()
                 .bodyToMono(String.class)
                 .doOnNext(res -> log.info("[AI] requested meetNo={}, res={}", meetNo, res))
-                .doOnError(e -> log.error("[AI] request failed meetNo={}", meetNo, e))
-                .subscribe();
+                .block(Duration.ofSeconds(10));
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/meeting/event/MeetingAiEventListener.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/meeting/event/MeetingAiEventListener.java
@@ -1,6 +1,7 @@
 package com.multi.mlpenterpriseapprovalsystem.meeting.event;
 
 import com.multi.mlpenterpriseapprovalsystem.common.client.MeetingAiClient;
+import com.multi.mlpenterpriseapprovalsystem.meeting.service.MeetingService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Async;
@@ -21,15 +22,22 @@ import org.springframework.transaction.event.TransactionalEventListener;
 public class MeetingAiEventListener {
 
     private final MeetingAiClient meetingAiClient;
+    private final MeetingService meetingService; // 서비스 주입
 
     @Async
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void on(MeetingAiRequestedEvent e) {
         try {
             meetingAiClient.requestAi(e.meetNo(), e.objectKey(), e.title());
+            log.info("[AI REQUEST SUCCESS] meetNo={}", e.meetNo());
         } catch (Exception ex) {
-            // 여기서 실패해도 DB는 이미 커밋됨
-            log.error("[AI REQUEST FAILED] meetNo={}, objectKey={}, title={}", e.meetNo(), e.objectKey(), e.title(), ex);
+            log.error("[AI REQUEST FAILED] meetNo={}, reason={}", e.meetNo(), ex.getMessage(), ex);
+
+            try {
+                meetingService.handleAiRequestFailure(e.meetNo(), "AI 서버 연결 실패: " + ex.getMessage());
+            } catch (Exception dbEx) {
+                log.error("[CRITICAL] Failed to update AI status to FAILED for meetNo={}", e.meetNo(), dbEx);
+            }
         }
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/meeting/service/MeetingService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/meeting/service/MeetingService.java
@@ -27,6 +27,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -480,5 +481,15 @@ public class MeetingService {
         meetingRepository.delete(meeting);
 
         return meetNo;
+    }
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleAiRequestFailure(Long meetNo, String errorMessage) {
+        Meeting meeting = meetingRepository.findByMeetNoAndIsDeletedFalse(meetNo)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEETING_NOT_FOUND));
+
+        meeting.markAiFailed(errorMessage);
+
+        log.info("[AI STATUS UPDATED TO FAILED] meetNo={}", meetNo);
     }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/domain/ProvDocument.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/domain/ProvDocument.java
@@ -44,7 +44,7 @@ public class ProvDocument extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(name = "proc_stat", nullable = false, length = 20)
     private ProvProcStat procStat;
-    @Column(name = "error_msg", length = 20)
+    @Column(name = "error_msg", columnDefinition = "TEXT")
     private String errorMsg;
 
 

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/event/ProvDocumentEventListener.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/event/ProvDocumentEventListener.java
@@ -1,0 +1,41 @@
+package com.multi.mlpenterpriseapprovalsystem.provdocument.event;
+
+import com.multi.mlpenterpriseapprovalsystem.common.client.EmbeddingClient;
+import com.multi.mlpenterpriseapprovalsystem.provdocument.service.ProvDocumentService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+/**
+ * 사내 규정 임베딩 등록 테스트 이벤트 리스너
+ *
+ * @author : 김승기
+ * @filename : ProvDocumentEventListener
+ * @since : 2026. 1. 8. 목요일
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ProvDocumentEventListener {
+
+    private final EmbeddingClient embeddingClient;
+    private final ProvDocumentService provDocumentService;
+
+    @Async
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(ProvEmbeddingRequestedEvent e) {
+        try {
+            // 이벤트에 담겨온 DTO를 그대로 사용
+            embeddingClient.requestProvEmbedding(e.embeddingReq());
+            log.info("[EMBEDDING REQUEST SUCCESS] provNo={}", e.provNo());
+        } catch (Exception ex) {
+            log.error("[EMBEDDING REQUEST FAILED] provNo={}, reason={}", e.provNo(), ex.getMessage());
+
+            // 네트워크 오류나 서버 다운 시 실패 상태 기록
+            provDocumentService.handleEmbeddingFailure(e.provNo(), "AI 서버 연결 실패: " + ex.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/event/ProvEmbeddingRequestedEvent.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/event/ProvEmbeddingRequestedEvent.java
@@ -1,0 +1,15 @@
+package com.multi.mlpenterpriseapprovalsystem.provdocument.event;
+
+import com.multi.mlpenterpriseapprovalsystem.provdocument.dto.ReqFastApiProvEmbeddingDto;
+
+/**
+ * 이벤트 리스너에 들어갈 dto
+ *
+ * @author : 김승기
+ * @filename : ProvEmbeddingRequestedEvent
+ * @since : 2026. 1. 8. 목요일
+ */
+public record ProvEmbeddingRequestedEvent(
+        Long provNo,
+        ReqFastApiProvEmbeddingDto embeddingReq
+) {}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/service/ProvDocumentService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/service/ProvDocumentService.java
@@ -16,12 +16,15 @@ import com.multi.mlpenterpriseapprovalsystem.notification.domain.NotificationTyp
 import com.multi.mlpenterpriseapprovalsystem.notification.service.NotificationService;
 import com.multi.mlpenterpriseapprovalsystem.provdocument.domain.ProvDocument;
 import com.multi.mlpenterpriseapprovalsystem.provdocument.dto.*;
+import com.multi.mlpenterpriseapprovalsystem.provdocument.event.ProvEmbeddingRequestedEvent;
 import com.multi.mlpenterpriseapprovalsystem.provdocument.repository.ProvDocumentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -46,6 +49,7 @@ public class ProvDocumentService {
     private final AttachmentRepository attachmentRepository;
     private final EmployeeRepository employeeRepository;
     private final NotificationService notificationService;
+    private final ApplicationEventPublisher publisher;
 
     @Transactional
     public Long create(String comId, ReqProvDocumentCreateDto req) {
@@ -90,9 +94,21 @@ public class ProvDocumentService {
                 .callbackUrl("/api/v1/prov-documents/" + doc.getProvNo() + "/embedding")
                 .build();
 
-        embeddingClient.requestProvEmbedding(embeddingReq);
+        publisher.publishEvent(new ProvEmbeddingRequestedEvent(doc.getProvNo(), embeddingReq));
+
 
         return doc.getProvNo();
+    }
+
+    /**
+     * AI 요청 실패 시 별도 트랜잭션으로 상태를 업데이트하는 메서드
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleEmbeddingFailure(Long provNo, String errorMessage) {
+        ProvDocument doc = provDocumentRepository.findById(provNo)
+                .orElseThrow(() -> new CustomException(ErrorCode.PROV_DOCUMENT_NOT_FOUND));
+        doc.markFailed(errorMessage); //
+        log.info("[EMBEDDING STATUS UPDATED TO FAILED] provNo={}", provNo);
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #399

## 📝 작업 내용
- meeting에서 실패 기능 추가
- prov_document 등록할때도 eventlistener로 하게 수정
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
