### PR TITLE
Design: 예약, 공유함 프론트 수정

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/cloud/controller/CloudTrashController.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/cloud/controller/CloudTrashController.java
@@ -121,4 +121,13 @@ public class CloudTrashController {
         cloudTrashService.purgeDeptFile(user, attachmentId);
         return ResponseEntity.ok(new ResponseDto<>(HttpStatus.OK, "부서 파일 영구삭제 성공", null));
     }
+
+    @PostMapping("/purge/dept/folder/{folderNo}")
+    public ResponseEntity<ResponseDto<Void>> purgeDeptFolder(
+            @PathVariable Long folderNo,
+            @AuthenticationPrincipal CustomUser user
+    ){
+        cloudTrashService.purgeDeptFolder(user, folderNo);
+        return ResponseEntity.ok(new ResponseDto<>(HttpStatus.OK, "부서 폴더 영구삭제 성공", null));
+    }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/cloud/repository/FolderRepository.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/cloud/repository/FolderRepository.java
@@ -110,7 +110,7 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
               a.entity_id AS parentFolderNo,
               f.scope AS scope,
               f.dep_no AS depNo,
-              f.owner_id AS ownerId,
+              a.created_by AS ownerId,
               a.deleted_by AS deletedBy,
               a.deleted_at AS deletedAt,
               a.delete_batch_id AS deleteBatchId,
@@ -287,6 +287,27 @@ public interface FolderRepository extends JpaRepository<Folder, Long> {
                 ORDER BY LENGTH(f.path) DESC
             """, nativeQuery = true)
     List<Long> findPrvtDeletedFolderNosInTree(String comId, String ownerId, Long rootId, String prefix);
+
+    @Query(value = """
+    SELECT f.folder_no
+    FROM folder f
+    WHERE f.com_id = :comId
+      AND LOWER(f.scope) = 'dept'
+      AND f.dep_no = :depNo
+      AND f.deleted_at IS NOT NULL
+      AND (
+           f.folder_no = :rootFolderNo
+        OR f.path = :basePath
+        OR f.path LIKE CONCAT(:basePath, '/%')
+      )
+    ORDER BY LENGTH(f.path) DESC
+""", nativeQuery = true)
+    List<Long> findDeptDeletedFolderNosInTree(
+            @Param("comId") String comId,
+            @Param("depNo") Long depNo,
+            @Param("rootFolderNo") Long rootFolderNo,
+            @Param("basePath") String basePath
+    );
 
 
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/cloud/service/CloudTrashService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/cloud/service/CloudTrashService.java
@@ -23,7 +23,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import software.amazon.awssdk.services.s3.S3Client;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Set;
 
@@ -109,11 +111,8 @@ public class CloudTrashService {
         String actor = user.getUsername();
 
         if (scope == FolderScope.DEPT) {
-            // ✅ DEPT는 관리자만
-            if (!isAdmin(user)) throw new CustomException(ErrorCode.TRASH_RESTORE_FORBIDDEN);
 
             Long depNo = resolveDepNo(user);
-            if (depNo == null) throw new CustomException(ErrorCode.DEPARTMENT_NOT_FOUND);
 
             // ✅ RESTORE 로그 적재 (복구 UPDATE 전에)
             cloudTrashLogRepository.insertRestoreLogsForDeptFoldersByBatch(comId, depNo, batchId, actor);
@@ -230,6 +229,19 @@ public class CloudTrashService {
 
         String comId = user.getComId();
         Long depNo = resolveDepNo(user);
+
+        LocalDate f = LocalDate.parse(from);
+        LocalDate t = LocalDate.parse(to);
+
+        if (t.isBefore(f)) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
+
+        // 최대 3개월(대략 92일) 제한 - 팀 기준에 맞게 90/92 조절
+        long days = ChronoUnit.DAYS.between(f, t);
+        if (days > 92) {
+            throw new CustomException(ErrorCode.INVALID_REQUEST);
+        }
 
         // ✅ 정책 방어: 10개씩
         int safeLimit = Math.min(Math.max(limit, 1), 10);
@@ -477,6 +489,65 @@ public class CloudTrashService {
 
         int deleted = attachmentRepository.hardDeleteDeletedCloudAttachmentById(comId, attachmentId);
         if (deleted == 0) throw new CustomException(ErrorCode.TRASH_ITEM_NOT_FOUND);
+    }
+
+    @Transactional
+    public void purgeDeptFolder(CustomUser user, Long folderNo) {
+        authCheck(user);
+
+        String comId = user.getComId();
+        String actor = user.getUsername();
+        Long depNo = resolveDepNo(user);
+
+        // 1) 루트 폴더 조회
+        Folder root = folderRepository.findByFolderNoAndComId(folderNo, comId)
+                .orElseThrow(() -> new CustomException(ErrorCode.FOLDER_NOT_FOUND));
+
+        // 2) DEPT + 같은 부서인지
+        if (root.getScope() != FolderScope.DEPT || !depNo.equals(root.getDepNo())) {
+            throw new CustomException(ErrorCode.TRASH_PURGE_FORBIDDEN);
+        }
+
+        // 3) 휴지통(삭제됨)인지
+        if (root.getDeletedAt() == null) {
+            throw new CustomException(ErrorCode.TRASH_ITEM_NOT_FOUND);
+        }
+
+        // 4) 권한: 관리자 OR 소유자(ownerId)
+        boolean isOwner = (actor != null && actor.equals(root.getOwnerId())); // Folder에 ownerId 필드가 있어야 함
+        if (!isAdmin(user) && !isOwner) {
+            throw new CustomException(ErrorCode.TRASH_PURGE_FORBIDDEN);
+        }
+
+        // 5) 트리(루트 포함) 폴더 번호들(자식부터) 확보
+        String basePath = normalizeBasePath(root.getPath(), root.getFolderNo());
+        List<Long> folderNosToDelete = folderRepository.findDeptDeletedFolderNosInTree(
+                comId, depNo, folderNo, basePath
+        );
+        if (folderNosToDelete == null || folderNosToDelete.isEmpty()) {
+            throw new CustomException(ErrorCode.TRASH_ITEM_NOT_FOUND);
+        }
+
+        // 6) 트리 내 (삭제된) 파일들의 S3 objectKey 모아서 삭제
+        List<String> keys = attachmentRepository.findDeptDeletedObjectKeysByFolderNos(
+                comId, depNo, folderNosToDelete
+        );
+        deleteObjectsFromS3(keys);
+
+        // 7) (선택) 감사 로그(원하면)
+        // cloudTrashLogRepository.insertManualPurgeLogForDeptFolder(comId, depNo, actor, root.getDeleteBatchId(), root.getFolderNo(), root.getFolderName());
+
+        // 8) DB 물리 삭제 (파일 → 폴더)
+        attachmentRepository.hardDeleteDeptDeletedAttachmentsByFolderNos(comId, depNo, folderNosToDelete);
+        folderRepository.hardDeleteFoldersByNos(comId, folderNosToDelete);
+    }
+
+    /** path가 null이어도 안전하게 prefix 만들기 */
+    private String normalizeBasePath(String path, Long folderNo) {
+        String p = (path == null || path.isBlank()) ? ("/" + folderNo) : path.trim();
+        if (!p.startsWith("/")) p = "/" + p;
+        while (p.endsWith("/") && p.length() > 1) p = p.substring(0, p.length() - 1);
+        return p;
     }
 
 

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/storage/repository/AttachmentRepository.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/storage/repository/AttachmentRepository.java
@@ -278,6 +278,41 @@ WHERE com_id = :comId
             @Param("attachmentId") Long attachmentId
     );
 
+    @Query(value = """
+    SELECT a.object_key
+    FROM attachment a
+    JOIN folder f ON f.folder_no = a.entity_id
+    WHERE a.com_id = :comId
+      AND a.domain = 'CLOUD'
+      AND a.status = 'DELETED'
+      AND a.entity_id IN (:folderNos)
+      AND LOWER(f.scope) = 'dept'
+      AND f.dep_no = :depNo
+""", nativeQuery = true)
+    List<String> findDeptDeletedObjectKeysByFolderNos(
+            @Param("comId") String comId,
+            @Param("depNo") Long depNo,
+            @Param("folderNos") List<Long> folderNos
+    );
+
+    @Modifying
+    @Query(value = """
+    DELETE a
+    FROM attachment a
+    JOIN folder f ON f.folder_no = a.entity_id
+    WHERE a.com_id = :comId
+      AND a.domain = 'CLOUD'
+      AND a.status = 'DELETED'
+      AND a.entity_id IN (:folderNos)
+      AND LOWER(f.scope) = 'dept'
+      AND f.dep_no = :depNo
+""", nativeQuery = true)
+    int hardDeleteDeptDeletedAttachmentsByFolderNos(
+            @Param("comId") String comId,
+            @Param("depNo") Long depNo,
+            @Param("folderNos") List<Long> folderNos
+    );
+
 
 }
 

--- a/src/main/resources/templates/cloud/admin-log.html
+++ b/src/main/resources/templates/cloud/admin-log.html
@@ -412,6 +412,9 @@
         console.log("[admin-log] scope(from url):", scope);
 
         const size = 10;  // 페이지당 10개
+        const MAX_PAGES = 5;      // 서버 정책(최대 5페이지)과 맞춤
+        let totalPages = 1;       // 확정된 총 페이지 수(1~5)
+        let lastQueryKey = "";    // 검색조건 바뀌었는지 판별
         let page = 0;     // 0-base page
 
         const el = {
@@ -440,6 +443,117 @@
 
             // ResponseDto { data: ... } 래핑이면 data 언랩
             return json && "data" in json ? json.data : json;
+        }
+
+        function buildQueryKey({ q, from, to }) {
+            return `${scope}|${from}|${to}|${q}`;
+        }
+
+        async function fetchSlice(p, { q, from, to }) {
+            const limit = size;
+            const offset = p * size;
+
+            const url =
+                `/api/v1/cloud/trash/admin-log?scope=${encodeURIComponent(scope)}`
+                + `&limit=${limit}&offset=${offset}`
+                + `&q=${encodeURIComponent(q)}`
+                + `&from=${encodeURIComponent(from)}`
+                + `&to=${encodeURIComponent(to)}`;
+
+            return await apiJson(url); // { items, hasNext, limit, offset }
+        }
+
+        // ✅ 0페이지 기준으로 hasNext를 따라가며 총 페이지(최대 5) 확정
+        async function detectTotalPages(firstSlice, params) {
+            // 결과가 없으면 페이징 없음
+            if (!firstSlice || !Array.isArray(firstSlice.items) || firstSlice.items.length === 0) return 1;
+
+            let total = 1;
+            let cur = firstSlice;
+            let nextPage = 1;
+
+            while (cur.hasNext && total < MAX_PAGES) {
+                const next = await fetchSlice(nextPage, params);
+
+                // 안전: 혹시 서버가 빈 배열을 주면 중단
+                if (!next || !Array.isArray(next.items) || next.items.length === 0) break;
+
+                total++;
+                cur = next;
+                nextPage++;
+            }
+
+            return total;
+        }
+
+        function fmtYMD(d){
+            const yyyy = d.getFullYear();
+            const mm = String(d.getMonth() + 1).padStart(2, "0");
+            const dd = String(d.getDate()).padStart(2, "0");
+            return `${yyyy}-${mm}-${dd}`;
+        }
+
+        function parseYMD(s){
+            if (!s) return null;
+            // input[type=date]는 YYYY-MM-DD
+            const [y,m,d] = s.split("-").map(Number);
+            if (!y || !m || !d) return null;
+            return new Date(y, m - 1, d); // 로컬 00:00
+        }
+
+        function addMonths(date, months){
+            const d = new Date(date);
+            const day = d.getDate();
+            d.setMonth(d.getMonth() + months);
+
+            // 말일 보정(예: 3/31 -1개월 => 3/03 같은 꼬임 방지)
+            if (d.getDate() !== day) d.setDate(0);
+            return d;
+        }
+
+        // ✅ 날짜 제약 적용: (1) to < from 금지 (2) 기간 3개월 초과 금지
+        function normalizeDateRange({ silent = false } = {}){
+            const from = parseYMD(el.fromDate.value);
+            const to   = parseYMD(el.toDate.value);
+
+            if (!from || !to) return;
+
+            // 1) 역전 방지: to >= from
+            if (to < from) {
+                el.toDate.value = el.fromDate.value;
+                if (!silent) alert("종료 날짜는 시작 날짜보다 빠를 수 없습니다.");
+            }
+
+            // 2) 3개월 제한: from >= (to - 3개월)
+            const to2 = parseYMD(el.toDate.value);
+            const minFrom = addMonths(to2, -3); // to 기준 3개월 전
+            const from2 = parseYMD(el.fromDate.value);
+
+            if (from2 < minFrom) {
+                el.fromDate.value = fmtYMD(minFrom);
+                if (!silent) alert("조회 기간은 최대 3개월까지만 가능합니다.");
+            }
+
+            // date picker 자체 제한도 같이 갱신
+            el.toDate.min = el.fromDate.value;
+            el.fromDate.max = el.toDate.value;
+
+            // 오늘 이후 선택 금지(원하면)
+            const today = new Date();
+            const todayStr = fmtYMD(today);
+            el.fromDate.max = Math.min(el.fromDate.max || todayStr, todayStr);
+            el.toDate.max = todayStr;
+        }
+
+        function bindDateGuards(){
+            // 오늘 이후 선택 금지(원하면 유지)
+            const todayStr = fmtYMD(new Date());
+            el.fromDate.max = todayStr;
+            el.toDate.max = todayStr;
+
+            // 상호 제약
+            el.fromDate.addEventListener("change", () => normalizeDateRange());
+            el.toDate.addEventListener("change", () => normalizeDateRange());
         }
 
         function actionLabel(a) {
@@ -526,8 +640,10 @@
                 return b;
             };
 
+            // 이전
             el.paging.appendChild(mkBtn("‹", () => loadLogs(current - 1), current === 0));
 
+            // total은 1~5로 확정되어 있으니 그대로 보여주면 됨
             const windowSize = 5;
             const start = Math.max(0, current - Math.floor(windowSize / 2));
             const end = Math.min(total - 1, start + windowSize - 1);
@@ -537,36 +653,43 @@
                 el.paging.appendChild(mkBtn(String(p + 1), () => loadLogs(p), false, p === current));
             }
 
+            // 다음
             el.paging.appendChild(mkBtn("›", () => loadLogs(current + 1), current >= total - 1));
         }
 
         async function loadLogs(p = 0) {
             page = p;
 
+            normalizeDateRange({ silent: true });
+
             const q = (el.q?.value || "").trim();
             const from = el.fromDate.value;
             const to = el.toDate.value;
 
-            const limit = size;
-            const offset = page * size;
+            const params = { q, from, to };
+            const key = buildQueryKey(params);
 
-            const url =
-                `/api/v1/cloud/trash/admin-log?scope=${encodeURIComponent(scope)}`
-                + `&limit=${limit}&offset=${offset}`
-                + `&q=${encodeURIComponent(q)}`
-                + `&from=${encodeURIComponent(from)}`
-                + `&to=${encodeURIComponent(to)}`;
+            // ✅ 검색조건이 바뀌면 totalPages를 다시 확정해야 함
+            const queryChanged = (key !== lastQueryKey);
+            if (queryChanged) {
+                lastQueryKey = key;
+                totalPages = 1; // 임시 리셋
+            }
 
-            console.log("[admin-log] request url:", url);
-
-            const slice = await apiJson(url); // { items, hasNext, limit, offset }
+            // 현재 페이지 데이터 로드
+            const slice = await fetchSlice(page, params);
 
             const rows = slice.items;
             render(rows);
 
-            const current = Math.floor((slice.offset || 0) / (slice.limit || size));
-            const total = slice.hasNext ? current + 2 : current + 1;
-            renderPaging(current, Math.min(total, 5));
+            // ✅ 처음 로드/검색조건 변경 시: 0페이지 기준으로 총 페이지 확정(최대 5)
+            if (queryChanged) {
+                // 0페이지부터 계산하는 게 “1페이지에서도 1,2,3이 안정적으로 보이게” 하는 포인트
+                const first = (page === 0) ? slice : await fetchSlice(0, params);
+                totalPages = await detectTotalPages(first, params);
+            }
+
+            renderPaging(page, totalPages);
         }
 
         async function toggleFolderDetail(btn) {
@@ -642,6 +765,9 @@
 
             el.fromDate.value = fmtYMD(weekAgo);
             el.toDate.value = fmtYMD(today);
+
+            bindDateGuards();
+            normalizeDateRange({ silent: true });
 
             loadLogs(0).catch(e => alert(e.message));
         });

--- a/src/main/resources/templates/cloud/cloud.html
+++ b/src/main/resources/templates/cloud/cloud.html
@@ -1616,6 +1616,16 @@
             createFolder().catch(e => alert(e.message));
         });
 
+        // ✅ 확장자 추출 유틸
+        function getExt(filename) {
+            const s = String(filename ?? "").trim();
+            const base = s.split("?")[0].split("#")[0];
+            const dot = base.lastIndexOf(".");
+            // ".gitignore" 같이 맨 앞 점만 있는 케이스는 확장자 취급 안 함
+            if (dot <= 0 || dot === base.length - 1) return "";
+            return base.slice(dot + 1).toLowerCase();
+        }
+
         el.ctxRename?.addEventListener("click", () => {
             closeCtxMenu();
 
@@ -1629,13 +1639,25 @@
             if (state.ctxKind === "file" && state.ctxAttachmentId) {
                 (async () => {
                     const oldName = state.ctxOriginalName || "";
+                    const oldExt = getExt(oldName);
+
                     let next = prompt("새 파일명(확장자 포함)", oldName);
                     if (!next) return;
                     next = next.trim();
 
+                    const nextExt = getExt(next);
+
+                    // 확장자를 '바꾼' 경우 경고(confirm)
+                    // - oldExt, nextExt 둘 다 존재하고 서로 다르면 변경으로 판단
+                    if (oldExt && nextExt && oldExt !== nextExt) {
+                        const ok = confirm(
+                            `확장자를 "${oldExt}" → "${nextExt}"로 변경하면 파일이 실행되지 않거나 정상 동작하지 않을 수 있습니다.\n계속하시겠습니까?`
+                        );
+                        if (!ok) return;
+                    }
+
                     // 확장자 안 쓰면 기존 확장자 유지
-                    const oldExt = oldName.includes(".") ? oldName.split(".").pop() : "";
-                    if (oldExt && !next.includes(".")) next = `${next}.${oldExt}`;
+                    if (oldExt && !nextExt) next = `${next}.${oldExt}`;
 
                     await apiJson(`/api/v1/attachments/${state.ctxAttachmentId}/rename`, {
                         method: "PATCH",

--- a/src/main/resources/templates/cloud/trash.html
+++ b/src/main/resources/templates/cloud/trash.html
@@ -2,6 +2,7 @@
 <html lang="ko"
       xmlns:th="http://www.thymeleaf.org"
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      xmlns:sec="http://www.thymeleaf.org/extras/spring-security"
       layout:decorate="~{layout}">
 
 <head>
@@ -404,7 +405,9 @@
         <!-- ✅ 휴지통 우클릭 메뉴(기본은 숨김) -->
         <div class="trash-ctx" id="trashCtx" role="menu" aria-label="휴지통 메뉴" style="display:none;">
             <button type="button" class="ctx-btn" id="ctxRestore" role="menuitem">복구</button>
-            <button type="button" class="ctx-btn" id="ctxPurgeDeptFile" role="menuitem" style="display:none;">
+            <button type="button" class="ctx-btn" id="ctxPurgeDeptFile"
+                    role="menuitem" style="display:none;" disabled
+                    title="관리자 또는 파일 권한자만 영구삭제할 수 있습니다.">
                 영구삭제
             </button>
             <button type="button" class="ctx-btn" id="ctxInfoToggle" role="menuitem">삭제 상세 정보</button>
@@ -438,20 +441,30 @@
 
 <th:block layout:fragment="pageScripts">
     <script th:inline="javascript">
+        /* =========================================================
+           0) CONST / STATE
+        ========================================================= */
+        const IS_ADMIN = /*[[${#authorization.expression(
+        "hasAnyAuthority(" +
+        "'SYS_ADMIN','COM_ADMIN','SEC_ADMIN','THR_ADMIN'," +
+        "'ROLE_SYS_ADMIN','ROLE_COM_ADMIN','ROLE_SEC_ADMIN','ROLE_THR_ADMIN'" +
+        ")"
+    )}]]*/ false;
+
+        const CURRENT_USERNAME = /*[[${#authentication?.name}]]*/ "";
         const TRASH_SCOPE = /*[[${trashScope}]]*/ "DEPT"; // "DEPT" | "PRVT"
         const SCOPE = String(TRASH_SCOPE || "DEPT").toUpperCase();
 
-        // ✅ 선택 영구삭제 API (서버에 맞춰 수정!)
-        // 예) "/api/v1/cloud/trash/purge/prvt"
         const PURGE_SELECTED_ENDPOINT = "/api/v1/cloud/trash/purge/prvt";
 
         const state = {
             selectedBatchId: null,
             selectedCardEl: null,
 
-            // ✅ PRVT 멀티선택용
+            // PRVT 멀티선택용
             selectedKeys: new Set(),
             lastClickedIndex: null,
+
             items: [],
             itemByKey: new Map(),
         };
@@ -461,11 +474,10 @@
             empty: document.getElementById("trashEmpty"),
 
             btnReload: document.getElementById("btnReload"),
-            btnEmpty: document.getElementById("btnEmpty"),                 // PRVT 전체 비우기
-            btnPurgeSelected: document.getElementById("btnPurgeSelected"), // PRVT 선택 삭제
+            btnEmpty: document.getElementById("btnEmpty"),
+            btnPurgeSelected: document.getElementById("btnPurgeSelected"),
         };
 
-        // ✅ 우클릭 메뉴 상태
         const ctx = {
             el: document.getElementById("trashCtx"),
             btnRestore: document.getElementById("ctxRestore"),
@@ -486,44 +498,63 @@
 
         ctx.el?.addEventListener("contextmenu", (e) => e.preventDefault(), true);
 
-        function safe(s){ return (s == null) ? "" : String(s); }
+        /* =========================================================
+           1) UTILS
+        ========================================================= */
+        function safe(s) { return (s == null) ? "" : String(s); }
 
-        function fmtDate(dt){
+        function normUser(v) { return safe(v).trim().toLowerCase(); }
+        function isSameUser(a, b) {
+            const aa = normUser(a), bb = normUser(b);
+            return aa.length > 0 && aa === bb;
+        }
+
+        function resolveOwnerId(it) {
+            // ✅ ResTrashItemDto.ownerId 기준
+            return safe(it?.ownerId);
+        }
+
+        function resolveDeletedBy(it) {
+            // deletedBy가 서버에서 내려오는 필드면 그걸 쓰면 됨
+            return safe(it?.deletedBy || it?.deletedByName || it?.deleterName || it?.deletedUserName || it?.deletedUser);
+        }
+
+        function fmtDate(dt) {
             if (!dt) return "";
             const d = new Date(dt);
             if (isNaN(d.getTime())) return String(dt);
             const yyyy = d.getFullYear();
-            const mm = String(d.getMonth()+1).padStart(2,"0");
-            const dd = String(d.getDate()).padStart(2,"0");
+            const mm = String(d.getMonth() + 1).padStart(2, "0");
+            const dd = String(d.getDate()).padStart(2, "0");
             return `${yyyy}-${mm}-${dd}`;
         }
 
-        function isFolder(it){
+        function isFolder(it) {
             return String(it?.type || "").toUpperCase() === "FOLDER";
         }
 
-        function getBatchId(it){
+        function getBatchId(it) {
             const raw =
-                it?.deleteBatchId
-                ?? it?.batchId
-                ?? it?.deletedBatchId
-                ?? it?.delete_batch_id
-                ?? it?.batch
-                ?? it?.extra1;
+                it?.deleteBatchId ??
+                it?.batchId ??
+                it?.deletedBatchId ??
+                it?.delete_batch_id ??
+                it?.batch ??
+                it?.extra1;
 
             return raw == null ? "" : String(raw).trim();
         }
 
-        function humanBytes(n){
+        function humanBytes(n) {
             if (n == null) return "";
             let v = Number(n);
-            const units = ["B","KB","MB","GB","TB"];
+            const units = ["B", "KB", "MB", "GB", "TB"];
             let i = 0;
             while (v >= 1024 && i < units.length - 1) { v /= 1024; i++; }
             return `${v.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
         }
 
-        function resolveFileIcon(it){
+        function resolveFileIcon(it) {
             const ICONS = {
                 word: "/images/icons/word.png",
                 excel: "/images/icons/excel.png",
@@ -536,17 +567,17 @@
             };
 
             const EXT_GROUPS = {
-                word: ["doc","docx"],
-                excel: ["xls","xlsx","csv"],
-                ppt: ["ppt","pptx"],
+                word: ["doc", "docx"],
+                excel: ["xls", "xlsx", "csv"],
+                ppt: ["ppt", "pptx"],
                 pdf: ["pdf"],
-                image: ["png","jpg","jpeg","gif","webp","svg","bmp","tif","tiff","heic"],
-                zip: ["zip","rar","7z","tar","gz","bz2","xz"],
-                code: ["js","ts","jsx","tsx","html","css","scss","less","json","xml","yml","yaml","md","py","java","c","cpp","go","rs","php","rb","kt","swift","sh","sql"],
+                image: ["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "tif", "tiff", "heic"],
+                zip: ["zip", "rar", "7z", "tar", "gz", "bz2", "xz"],
+                code: ["js", "ts", "jsx", "tsx", "html", "css", "scss", "less", "json", "xml", "yml", "yaml", "md", "py", "java", "c", "cpp", "go", "rs", "php", "rb", "kt", "swift", "sh", "sql"],
             };
 
-            const name = safe(it.originalName || it.name || it.title || "");
-            let ext = safe(it.ext || "").toLowerCase();
+            const name = safe(it?.originalName || it?.name || it?.title || "");
+            let ext = safe(it?.ext || "").toLowerCase();
             if (!ext && name.includes(".")) ext = name.split(".").pop().toLowerCase();
 
             let type = "unknown";
@@ -576,24 +607,51 @@
             return (json && typeof json === "object" && "data" in json) ? json.data : json;
         }
 
-        function closeTrashCtx(){
+        /* =========================================================
+           2) CONTEXT MENU
+        ========================================================= */
+        function closeTrashCtx() {
             if (!ctx.el) return;
             ctx.el.style.display = "none";
             ctx.currentBatchId = null;
             ctx.currentItem = null;
+            ctx.isInfoOpen = false;
+            if (ctx.infoWrap) ctx.infoWrap.style.display = "none";
+            if (ctx.btnInfo) ctx.btnInfo.textContent = "삭제 상세 정보";
         }
 
-        function openTrashCtx(x, y, item, batchId){
+        function positionCtx(x, y) {
+            if (!ctx.el) return;
+            ctx.el.style.left = x + "px";
+            ctx.el.style.top = y + "px";
+            ctx.el.style.display = "block";
+
+            requestAnimationFrame(() => {
+                const rect = ctx.el.getBoundingClientRect();
+                const pad = 8;
+
+                let left = x, top = y;
+                const maxL = window.innerWidth - rect.width - pad;
+                const maxT = window.innerHeight - rect.height - pad;
+
+                if (left > maxL) left = maxL;
+                if (top > maxT) top = maxT;
+
+                ctx.el.style.left = Math.max(pad, left) + "px";
+                ctx.el.style.top = Math.max(pad, top) + "px";
+            });
+        }
+
+        function openTrashCtx(x, y, item, batchId) {
             if (!ctx.el) return;
 
             ctx.openedAt = Date.now();
-            ctx.currentItem = item;
-            ctx.currentBatchId = batchId || null;
+            ctx.currentItem = item || {};
+            ctx.currentBatchId = (String(batchId ?? "").trim() || null);
 
             const name = safe(item?.originalName || item?.name || item?.title || ("item-" + item?.id));
             const deletedAt = fmtDate(item?.deletedAt);
-            const deletedBy =
-                safe(item?.deletedByName || item?.deletedBy || item?.deletedUserName || item?.deletedUser || item?.deleterName) || "-";
+            const deletedBy = resolveDeletedBy(item) || "-";
 
             const folder = isFolder(item);
             const sizeText = folder ? "폴더" : (item?.size != null ? humanBytes(item.size) : "-");
@@ -603,52 +661,45 @@
             ctx.infoDeletedAt && (ctx.infoDeletedAt.textContent = deletedAt || "-");
             ctx.infoDeletedBy && (ctx.infoDeletedBy.textContent = deletedBy || "-");
 
-            const b = String(batchId ?? "").trim();
-            ctx.currentBatchId = b || null;
+            // 복구 버튼: batchId 있으면 가능, 없으면 id 있을 때만(단건복구가 있는 경우 대비)
             const hasId = item && item.id != null;
-            ctx.btnRestore && (ctx.btnRestore.disabled = (b.length === 0 && !hasId));
+            ctx.btnRestore && (ctx.btnRestore.disabled = (!ctx.currentBatchId && !hasId));
 
-            // ✅ DEPT + FILE일 때만 "영구삭제" 버튼 노출
+            // ✅ 영구삭제 버튼 정책(관리자 OR ownerId)
+            const isDept = (SCOPE === "DEPT");
+            const type = String(item?.type || "").toUpperCase();
+            const isTarget = (type === "FILE" || type === "FOLDER");
+            const isOwner = isSameUser(resolveOwnerId(item), CURRENT_USERNAME);
+
+            const canPurge = isDept && isTarget && (IS_ADMIN || isOwner);
+
             if (ctx.btnPurgeDeptFile) {
-                const isDept = (SCOPE === "DEPT");
-                const isFile = String(item?.type || "").toUpperCase() === "FILE";
-                const canShow = isDept && isFile;
+                // DEPT에서만 노출 (FILE/FOLDER 둘 다)
+                ctx.btnPurgeDeptFile.style.display = (isDept && isTarget) ? "block" : "none";
+                ctx.btnPurgeDeptFile.disabled = !(canPurge && item?.id != null);
 
-                ctx.btnPurgeDeptFile.style.display = canShow ? "block" : "none";
-                ctx.btnPurgeDeptFile.disabled = !canShow || item?.id == null;
+                ctx.btnPurgeDeptFile.title = canPurge
+                    ? "영구삭제"
+                    : "관리자 또는 소유자(ownerId)만 영구삭제할 수 있습니다.";
             }
 
+            // 상세정보 닫힌 상태로 시작
             ctx.isInfoOpen = false;
             if (ctx.infoWrap) ctx.infoWrap.style.display = "none";
             if (ctx.btnInfo) ctx.btnInfo.textContent = "삭제 상세 정보";
 
-            ctx.el.style.left = x + "px";
-            ctx.el.style.top  = y + "px";
-            ctx.el.style.display = "block";
-
-            requestAnimationFrame(() => {
-                const rect = ctx.el.getBoundingClientRect();
-                const pad = 8;
-
-                let left = x, top = y;
-                const maxL = window.innerWidth  - rect.width  - pad;
-                const maxT = window.innerHeight - rect.height - pad;
-
-                if (left > maxL) left = maxL;
-                if (top  > maxT) top  = maxT;
-
-                ctx.el.style.left = Math.max(pad, left) + "px";
-                ctx.el.style.top  = Math.max(pad, top)  + "px";
-            });
+            positionCtx(x, y);
         }
 
+        // 상세정보 토글(한 번만 바인딩)
         ctx.btnInfo?.addEventListener("click", () => {
-            if (!ctx.infoWrap) return;
+            if (!ctx.infoWrap || !ctx.el) return;
 
             ctx.isInfoOpen = !ctx.isInfoOpen;
             ctx.infoWrap.style.display = ctx.isInfoOpen ? "block" : "none";
             ctx.btnInfo.textContent = ctx.isInfoOpen ? "삭제 상세 정보 숨기기" : "삭제 상세 정보";
 
+            // 아래로 튀어나오면 위로 올림
             const rect = ctx.el.getBoundingClientRect();
             const pad = 8;
             const overflowBottom = rect.bottom - (window.innerHeight - pad);
@@ -658,7 +709,7 @@
             }
         });
 
-        // ✅ 복구 클릭
+        // 복구 클릭(한 번만 바인딩)
         ctx.btnRestore?.addEventListener("click", async () => {
             const batchId = ctx.currentBatchId;
             const item = ctx.currentItem;
@@ -675,32 +726,38 @@
             }
         });
 
-        async function purgeDeptFileOne(item){
+        async function purgeDeptOne(item) {
+            if (SCOPE !== "DEPT") return;
+
+            const type = String(item?.type || "").toUpperCase();
             const id = item?.id;
-            if (id == null) return alert("삭제할 파일 ID가 없습니다.");
 
-            if (!confirm("이 파일을 영구삭제할까요?\n(되돌릴 수 없습니다)")) return;
+            if (id == null) {
+                return alert(type === "FOLDER" ? "삭제할 폴더 ID가 없습니다." : "삭제할 파일 ID가 없습니다.");
+            }
 
-            await apiJson(`/api/v1/cloud/trash/purge/dept/file/${encodeURIComponent(id)}`, {
-                method: "POST"
-            });
+            const label = (type === "FOLDER") ? "폴더" : "파일";
+            if (!confirm(`${label}을(를) 영구삭제할까요?\n(되돌릴 수 없습니다)`)) return;
 
+            const endpoint =
+                (type === "FOLDER")
+                    ? `/api/v1/cloud/trash/purge/dept/folder/${encodeURIComponent(id)}`
+                    : `/api/v1/cloud/trash/purge/dept/file/${encodeURIComponent(id)}`;
+
+            await apiJson(endpoint, { method: "POST" });
             await loadTrash();
             alert("영구삭제 완료!");
         }
 
+        // 영구삭제 클릭(한 번만 바인딩)
         ctx.btnPurgeDeptFile?.addEventListener("click", async () => {
             const item = ctx.currentItem;
             closeTrashCtx();
-
-            try{
-                await purgeDeptFileOne(item);
-            }catch(e){
-                alert(e.message);
-            }
+            try { await purgeDeptOne(item); }
+            catch (e) { alert(e.message); }
         });
 
-        // ✅ 바깥 클릭/스크롤/ESC 닫기
+        // 바깥 클릭/스크롤/ESC 닫기
         document.addEventListener("pointerdown", (e) => {
             if (!ctx.el || ctx.el.style.display !== "block") return;
             if (e.target.closest("#trashCtx")) return;
@@ -712,22 +769,22 @@
         document.addEventListener("keydown", (e) => { if (e.key === "Escape") closeTrashCtx(); });
 
         /* =========================================================
-           ✅ PRVT 멀티 선택(선택 삭제 버튼 enable/disable)
+           3) SELECT / RENDER
         ========================================================= */
-        function getItemKey(it){
+        function getItemKey(it) {
             const t = String(it?.type || "ITEM").toUpperCase();
             const id = (it?.id != null) ? String(it.id) : "";
             const b = getBatchId(it);
             return id ? `${t}:${id}` : (b ? `BATCH:${b}` : `TMP:${Math.random().toString(36).slice(2)}`);
         }
 
-        function updateTrashActionButtons(){
+        function updateTrashActionButtons() {
             if (SCOPE !== "PRVT") return;
             if (!el.btnPurgeSelected) return;
             el.btnPurgeSelected.disabled = (state.selectedKeys.size === 0);
         }
 
-        function clearSelection(){
+        function clearSelection() {
             state.selectedBatchId = null;
             if (state.selectedCardEl) state.selectedCardEl.classList.remove("selected");
             state.selectedCardEl = null;
@@ -738,7 +795,7 @@
             updateTrashActionButtons();
         }
 
-        function selectCard(cardEl, batchId){
+        function selectCard(cardEl, batchId) {
             if (state.selectedCardEl) state.selectedCardEl.classList.remove("selected");
             cardEl.classList.add("selected");
             state.selectedCardEl = cardEl;
@@ -747,7 +804,7 @@
             state.selectedBatchId = b || null;
         }
 
-        function render(items){
+        function render(items) {
             state.items = items || [];
             state.itemByKey.clear();
             clearSelection();
@@ -758,14 +815,14 @@
 
             // batch 개수 계산(배지용)
             const batchCount = new Map();
-            for (const it of state.items){
+            for (const it of state.items) {
                 const b = getBatchId(it);
                 if (!b) continue;
                 batchCount.set(b, (batchCount.get(b) || 0) + 1);
             }
 
             // 최신 삭제순
-            const sorted = [...state.items].sort((a,b) => {
+            const sorted = [...state.items].sort((a, b) => {
                 const ta = new Date(a.deletedAt || 0).getTime();
                 const tb = new Date(b.deletedAt || 0).getTime();
                 return tb - ta;
@@ -785,7 +842,7 @@
                 card.dataset.itemId = safe(it?.id || "");
                 card.className = folder ? "folder-card" : "file-card";
 
-                // ✅ 체크박스(hover/selected UI)
+                // 체크 UI
                 const check = document.createElement("div");
                 check.className = "card-check";
                 card.appendChild(check);
@@ -840,7 +897,7 @@
                     card.appendChild(meta);
                 }
 
-                // ✅ 클릭: PRVT면 멀티 선택(Cloud와 동일 UX), DEPT면 배치 단일 선택
+                // 클릭: PRVT 멀티 / DEPT 단일(batch)
                 card.addEventListener("click", (e) => {
                     e.stopPropagation();
 
@@ -852,14 +909,13 @@
                         const isRange = e.shiftKey;
 
                         if (!isToggle && !isRange) {
-                            // 단일 클릭 -> 다른 선택 해제
                             state.selectedKeys.clear();
                             cards.forEach(c => c.classList.remove("selected"));
                         }
 
                         if (isRange && state.lastClickedIndex != null) {
-                            const [a, b] = [state.lastClickedIndex, myIdx].sort((x,y)=>x-y);
-                            for (let i=a; i<=b; i++){
+                            const [a, b] = [state.lastClickedIndex, myIdx].sort((x, y) => x - y);
+                            for (let i = a; i <= b; i++) {
                                 const c = cards[i];
                                 if (!c) continue;
                                 c.classList.add("selected");
@@ -880,11 +936,11 @@
                         return;
                     }
 
-                    // DEPT: 기존처럼 batch 단일 선택
+                    // DEPT: batch 단일 선택
                     selectCard(card, batchId);
                 });
 
-                // DEPT만 더블클릭 복구(선택 UX 충돌 방지)
+                // DEPT만 더블클릭 복구
                 card.addEventListener("dblclick", async () => {
                     if (SCOPE === "PRVT") return;
                     if (!batchId) return;
@@ -897,7 +953,10 @@
             updateTrashActionButtons();
         }
 
-        async function loadTrash(){
+        /* =========================================================
+           4) API ACTIONS
+        ========================================================= */
+        async function loadTrash() {
             const items = await apiJson(`/api/v1/cloud/trash?scope=${encodeURIComponent(SCOPE)}&limit=200&offset=0`);
             const arr =
                 Array.isArray(items) ? items :
@@ -907,7 +966,7 @@
             render(arr);
         }
 
-        async function restoreBatch(batchId){
+        async function restoreBatch(batchId) {
             if (!batchId) return;
             if (!confirm("삭제한 파일을 복구할까요?")) return;
 
@@ -919,16 +978,12 @@
             alert("복구 완료!");
         }
 
-        /* =========================================================
-           ✅ PRVT: 선택 삭제 / 휴지통 비우기
-        ========================================================= */
-        async function purgeSelectedPrvt(){
+        async function purgeSelectedPrvt() {
             if (SCOPE !== "PRVT") return;
 
             const keys = Array.from(state.selectedKeys);
             if (keys.length === 0) return alert("삭제할 항목을 선택해주세요.");
 
-            // 서버로 보낼 payload(기본형): items: [{type, id}]
             const items = keys
                 .map(k => state.itemByKey.get(k))
                 .filter(Boolean)
@@ -939,7 +994,6 @@
 
             if (!confirm(`선택한 ${items.length}개를 영구 삭제할까요?\n(되돌릴 수 없습니다)`)) return;
 
-            // ✅ TODO: 서버 엔드포인트/바디 규격에 맞춰 여기만 수정하면 됨
             await apiJson(PURGE_SELECTED_ENDPOINT, {
                 method: "POST",
                 body: JSON.stringify({ items }),
@@ -949,30 +1003,31 @@
             alert("선택 삭제 완료!");
         }
 
+        /* =========================================================
+           5) BINDINGS
+        ========================================================= */
         el.btnPurgeSelected?.addEventListener("click", () => {
             purgeSelectedPrvt().catch(e => alert(e.message));
         });
 
-        el.btnReload?.addEventListener("click", () => loadTrash().catch(e => alert(e.message)));
+        el.btnReload?.addEventListener("click", () => {
+            loadTrash().catch(e => alert(e.message));
+        });
 
-        // PRVT 비우기
         el.btnEmpty?.addEventListener("click", async () => {
+            if (SCOPE !== "PRVT") return;
             if (!confirm("휴지통을 비울까요?")) return;
-            try{
+
+            try {
                 await apiJson(`/api/v1/cloud/trash/empty/prvt`, { method: "POST" });
                 await loadTrash();
                 alert("휴지통 비우기 완료!");
-            }catch(e){
+            } catch (e) {
                 alert(e.message);
             }
         });
 
-        /* =========================================================
-           ✅ 우클릭(컨텍스트 메뉴) 이벤트 위임
-           - PRVT에서는 우클릭한 카드만 단일 선택으로 맞춤
-           - DEPT는 배치 선택 유지
-        ========================================================= */
-        function bindTrashGridContextMenu(){
+        function bindTrashGridContextMenu() {
             el.grid?.addEventListener("contextmenu", (e) => {
                 const cardEl = e.target.closest(".folder-card, .file-card");
                 if (!cardEl || !el.grid.contains(cardEl)) return;
@@ -981,9 +1036,7 @@
                 e.stopPropagation();
 
                 let batchId = (cardEl.dataset.batchId || "").trim();
-
-                const itemId = (cardEl.dataset.itemId || "").trim();
-                const item = (state.items || []).find(it => String(it?.id ?? "") === itemId) || null;
+                const item = state.itemByKey.get(cardEl.dataset.key) || null;
 
                 if (!batchId && item) {
                     batchId = getBatchId(item);

--- a/src/main/resources/templates/reservation/corporatecars/corporate-car-reservation.html
+++ b/src/main/resources/templates/reservation/corporatecars/corporate-car-reservation.html
@@ -683,8 +683,19 @@
 
             cancelBtn.innerText = "닫기";
 
-            const carName = pick(resv, ["carName", "corporateCarName", "car.carName"], "-");
-            const plateNo = pick(resv, ["plateNo", "car.plateNo", "carPlateNo"], "-");
+            const carNo = pick(resv, ["carNo", "corporateCarNo", "car.carNo"], null);
+
+            // ✅ fallback 1) 테이블 row에 심어둔 plateNo 사용
+            const row = carNo ? document.querySelector(`.car-row[data-car-no="${carNo}"]`) : null;
+            const fallbackPlate = row?.dataset?.plateNo || "-";
+
+            // ✅ fallback 2) 차량 목록(CARS)에서도 plateNo 가져올 수 있게(있으면 더 정확)
+            const carObj = CARS.find(c => String(pick(c, ["carNo","corporateCarNo","id"], "")) === String(carNo));
+            const fallbackPlate2 = carObj ? pick(carObj, ["plateNo","carPlateNo","plate"], fallbackPlate) : fallbackPlate;
+
+            const carName = pick(resv, ["carName", "corporateCarName", "car.carName"], row?.querySelector(".car-name")?.innerText?.split(" (")?.[0] ?? "-");
+            const plateNo = pick(resv, ["plateNo", "car.plateNo", "carPlateNo"], fallbackPlate2);
+
             const resvDate = pick(resv, ["resvDate", "date"], resv.startedAt ? String(resv.startedAt).substring(0, 10) : "-");
 
             const startRaw = pick(resv, ["startTime"], resv.startedAt ? String(resv.startedAt).substring(11, 19) : null);

--- a/src/main/resources/templates/reservation/corporatecars/corporate-car-reservation.html
+++ b/src/main/resources/templates/reservation/corporatecars/corporate-car-reservation.html
@@ -361,6 +361,47 @@
             return res;
         }
 
+        function hmToMin(hm){
+            const [h,m] = String(hm).split(":").map(Number);
+            return (h*60) + (m||0);
+        }
+
+        function getResvDate(r){
+            return r.resvDate ?? (r.startedAt ? String(r.startedAt).substring(0,10) : null);
+        }
+
+        function getResvStartHM(r){
+            return r.startTime ? String(r.startTime).substring(0,5)
+                : (r.startedAt ? String(r.startedAt).substring(11,16) : null);
+        }
+
+        function getResvEndHM(r){
+            return r.endTime ? String(r.endTime).substring(0,5)
+                : (r.endedAt ? String(r.endedAt).substring(11,16) : null);
+        }
+
+        // 차량용 충돌 체크
+        function hasConflict({ carNo, dateStr, startTime, endTime }){
+            const s = hmToMin(startTime);
+            const e = hmToMin(endTime);
+
+            return (RESERVATIONS || []).some(r => {
+                const rCarNo = pick(r, ["carNo", "corporateCarNo", "car.carNo"], null);
+                if (String(rCarNo) !== String(carNo)) return false;
+                if (getResvDate(r) !== dateStr) return false;
+
+                const rs = getResvStartHM(r);
+                const re = getResvEndHM(r);
+                if (!rs || !re) return false;
+
+                const rS = hmToMin(rs);
+                const rE = hmToMin(re);
+
+                // 겹침 조건: !(내끝 <= 상대시작 || 내시작 >= 상대끝)
+                return !(e <= rS || s >= rE);
+            });
+        }
+
         function get(obj, path) {
             return path.split(".").reduce((o, k) => o?.[k], obj);
         }
@@ -727,16 +768,32 @@
         cancelBtn.onclick = () => { modal.style.display = "none"; };
 
         reserveBtn.onclick = async () => {
+            const carNo = Number(modal.dataset.carNo);
+            const dateStr = currentDate.format("YYYY-MM-DD");
+            const startTime = modal.dataset.start; // "HH:mm"
+            const endTime   = modal.dataset.end;   // "HH:mm"
+
             const body = {
-                carNo: Number(modal.dataset.carNo),
-                resvDate: currentDate.format("YYYY-MM-DD"),
-                startTime: modal.dataset.start,
-                endTime: modal.dataset.end,
+                carNo,
+                resvDate: dateStr,
+                startTime,
+                endTime,
                 purp: document.getElementById("purpose").value
             };
 
             if (!body.carNo) {
                 alert("차량 식별자(carNo)가 없습니다. 차량 목록 응답에 carNo/id가 내려오는지 확인해주세요.");
+                return;
+            }
+
+            // ✅ 1) 예약 직전 최신 데이터로 갱신
+            await loadReservations();
+
+            // ✅ 2) 최신 데이터 기준으로 충돌 체크
+            if (hasConflict({ carNo, dateStr, startTime, endTime })) {
+                alert("이미 다른 사용자가 해당 시간에 예약했습니다.\n새로고침 후 다른 시간을 선택해주세요.");
+                clearSelection();
+                modal.style.display = "none";
                 return;
             }
 
@@ -747,8 +804,19 @@
             });
 
             if (!res.ok) {
-                const msg = await res.text();
-                alert("예약 실패: " + msg);
+                // 서버가 text만 주는 경우도 있고 json 주는 경우도 있어서 안전처리
+                let msg = "";
+                try {
+                    const errJson = await res.json();
+                    msg = errJson?.message || JSON.stringify(errJson);
+                } catch {
+                    msg = await res.text();
+                }
+
+                alert("예약 실패: " + (msg || "알 수 없는 오류"));
+
+                // ✅ 실패 시에도 최신화
+                await loadReservations();
                 return;
             }
 
@@ -784,11 +852,11 @@
 
             // ✅ 여기서 이제 row.dataset.carNo가 항상 존재
             const carNo = row.dataset.carNo;
-            if (!carNo) {
+            // ✅ "null"/"undefined"/"" 방지
+            if (!carNo || carNo === "null" || carNo === "undefined") {
                 alert("차량 식별자(carNo)가 없습니다. 차량 목록 응답에 carNo/id가 내려오는지 확인해주세요.");
                 return;
             }
-
             const carLabel = row.querySelector(".car-name").innerText;
 
             const allCells = [...row.querySelectorAll(".time-cell")];
@@ -812,6 +880,14 @@
             modal.dataset.start = idxToTime(startIdx);
             modal.dataset.end = idxToTime(endIdx);
         };
+
+        setInterval(() => {
+            loadReservations().catch(()=>{});
+        }, 30000);
+
+        document.addEventListener("visibilitychange", () => {
+            if (!document.hidden) loadReservations().catch(()=>{});
+        });
 
         async function loadMe() {
             const res = await apiFetch("/api/v1/employees/me");

--- a/src/main/resources/templates/reservation/meetingrooms/meeting-room-reservation.html
+++ b/src/main/resources/templates/reservation/meetingrooms/meeting-room-reservation.html
@@ -386,6 +386,43 @@
             return res;
         }
 
+        function hmToMin(hm){
+            const [h,m] = String(hm).split(":").map(Number);
+            return (h*60) + (m||0);
+        }
+
+        function getResvDate(r){
+            return r.resvDate ?? (r.startedAt ? String(r.startedAt).substring(0,10) : null);
+        }
+        function getResvStartHM(r){
+            return r.startTime ? String(r.startTime).substring(0,5)
+                : (r.startedAt ? String(r.startedAt).substring(11,16) : null);
+        }
+        function getResvEndHM(r){
+            return r.endTime ? String(r.endTime).substring(0,5)
+                : (r.endedAt ? String(r.endedAt).substring(11,16) : null);
+        }
+
+        function hasConflict({ roomNo, dateStr, startTime, endTime }){
+            const s = hmToMin(startTime);
+            const e = hmToMin(endTime);
+
+            return (RESERVATIONS || []).some(r => {
+                if (String(r.roomNo) !== String(roomNo)) return false;
+                if (getResvDate(r) !== dateStr) return false;
+
+                const rs = getResvStartHM(r);
+                const re = getResvEndHM(r);
+                if (!rs || !re) return false;
+
+                const rS = hmToMin(rs);
+                const rE = hmToMin(re);
+
+                // 겹침 조건: !(내끝 <= 상대시작 || 내시작 >= 상대끝)
+                return !(e <= rS || s >= rE);
+            });
+        }
+
         function get(obj, path) {
             return path.split(".").reduce((o, k) => o?.[k], obj);
         }
@@ -729,11 +766,28 @@
                 return;
             }
 
+            const roomNo = Number(modal.dataset.roomNo);
+            const dateStr = currentDate.format("YYYY-MM-DD");
+            const startTime = modal.dataset.start; // "HH:mm"
+            const endTime   = modal.dataset.end;   // "HH:mm"
+
+            // ✅ 1) 예약 직전 최신 데이터로 갱신
+            await loadReservations();
+
+            // ✅ 2) 최신 데이터 기준으로 충돌 체크
+            if (hasConflict({ roomNo, dateStr, startTime, endTime })) {
+                alert("이미 다른 사용자가 해당 시간에 예약했습니다.\n새로고침 후 다른 시간을 선택해주세요.");
+                clearSelection();
+                modal.style.display = "none";
+                // 최신 예약이 이미 로드되어 paintReservations()까지 됨
+                return;
+            }
+
             const body = {
-                roomNo: Number(modal.dataset.roomNo),
-                resvDate: currentDate.format("YYYY-MM-DD"),
-                startTime: modal.dataset.start,
-                endTime: modal.dataset.end,
+                roomNo,
+                resvDate: dateStr,
+                startTime,
+                endTime,
                 purp: document.getElementById("purpose").value,
                 attendeeIds: selectedAttendees.map(a => a.empId)
             };
@@ -745,8 +799,16 @@
             });
 
             if (!res.ok) {
-                const msg = await res.text();
-                alert("예약 실패: " + msg);
+                // ✅ 서버가 409 같은 걸로 내려주면 여기서 메시지 분기 가능
+                let err = null;
+                try { err = await res.json(); } catch { err = { message: await res.text() }; }
+
+                // 서버가 아직 500으로 뭉개도 UX는 이렇게 처리 가능
+                const msg = err?.message || "예약 실패";
+                alert(msg.includes("예약") ? msg : "예약에 실패했습니다. (이미 예약되었을 수 있어요)\n새로고침 후 다시 시도해주세요.");
+
+                // ✅ 실패 시 최신화
+                await loadReservations();
                 return;
             }
 
@@ -754,6 +816,16 @@
             clearSelection();
             await loadReservations();
         };
+
+        // 30초마다 예약만 갱신 (원하면 15~60초로)
+        setInterval(() => {
+            loadReservations().catch(()=>{});
+        }, 30000);
+
+        // 탭 다시 활성화되면 갱신
+        document.addEventListener("visibilitychange", () => {
+            if (!document.hidden) loadReservations().catch(()=>{});
+        });
 
         deleteBtn.onclick = async () => {
             const resvNo = modal.dataset.resvNo;

--- a/src/main/resources/templates/reservation/sharedequipment/shared-equipment-reservation.html
+++ b/src/main/resources/templates/reservation/sharedequipment/shared-equipment-reservation.html
@@ -373,6 +373,51 @@
             return res;
         }
 
+        function hmToMin(hm){
+            const [h,m] = String(hm).split(":").map(Number);
+            return (h * 60) + (m || 0);
+        }
+
+        function getResvDate(r){
+            return r.resvDate ?? (r.startedAt ? String(r.startedAt).substring(0, 10) : null);
+        }
+
+        function getResvStartHM(r){
+            return r.startTime ? String(r.startTime).substring(0, 5)
+                : (r.startedAt ? String(r.startedAt).substring(11, 16) : null);
+        }
+
+        function getResvEndHM(r){
+            return r.endTime ? String(r.endTime).substring(0, 5)
+                : (r.endedAt ? String(r.endedAt).substring(11, 16) : null);
+        }
+
+        function getEqNoFrom(obj){
+            return pick(obj, ["eqNo", "sharedEquipmentNo", "equipmentNo", "eq.eqNo"], null);
+        }
+
+        // ✅ 설비용 충돌 체크
+        function hasConflict({ eqNo, dateStr, startTime, endTime }){
+            const s = hmToMin(startTime);
+            const e = hmToMin(endTime);
+
+            return (RESERVATIONS || []).some(r => {
+                const rEqNo = getEqNoFrom(r);
+                if (String(rEqNo) !== String(eqNo)) return false;
+                if (getResvDate(r) !== dateStr) return false;
+
+                const rs = getResvStartHM(r);
+                const re = getResvEndHM(r);
+                if (!rs || !re) return false;
+
+                const rS = hmToMin(rs);
+                const rE = hmToMin(re);
+
+                // 겹침 조건: !(내끝 <= 상대시작 || 내시작 >= 상대끝)
+                return !(e <= rS || s >= rE);
+            });
+        }
+
         function get(obj, path) {
             return path.split(".").reduce((o, k) => o?.[k], obj);
         }
@@ -739,37 +784,42 @@
         cancelBtn.onclick = () => { modal.style.display = "none"; };
 
         reserveBtn.onclick = async () => {
-            const eqNoRaw = modal.dataset.eqNo;     // 문자열 그대로
-            const start = modal.dataset.start;
-            const end = modal.dataset.end;
+            const eqNoRaw = modal.dataset.eqNo;     // 문자열
+            const dateStr = currentDate.format("YYYY-MM-DD");
+            const startTime = modal.dataset.start;  // "HH:mm"
+            const endTime   = modal.dataset.end;    // "HH:mm"
 
-            if (!eqNoRaw) {
+            // ✅ "null"/"undefined"/"" 방지
+            if (!eqNoRaw || eqNoRaw === "null" || eqNoRaw === "undefined") {
                 alert("설비 식별자(eqNo)가 없습니다. 설비 목록 응답에 eqNo/id가 내려오는지 확인해주세요.");
                 return;
             }
-            if (!start || !end) {
+            if (!startTime || !endTime) {
                 alert("예약 시간이 설정되지 않았습니다. 시간을 다시 선택해주세요.");
                 return;
             }
 
-            // ✅ 숫자면 Number로, 아니면 문자열 그대로
-            const eqNoVal = /^\d+$/.test(eqNoRaw) ? Number(eqNoRaw) : eqNoRaw;
+            // ✅ 1) 예약 직전 최신 데이터로 갱신
+            await loadReservations();
 
-            // (추가 안전장치) 숫자로 변환했는데 NaN이면 막기
-            if (typeof eqNoVal === "number" && Number.isNaN(eqNoVal)) {
-                alert("설비 식별자(eqNo)가 올바르지 않습니다: " + eqNoRaw);
+            // ✅ 2) 최신 데이터 기준으로 충돌 체크
+            if (hasConflict({ eqNo: eqNoRaw, dateStr, startTime, endTime })) {
+                alert("이미 다른 사용자가 해당 시간에 예약했습니다.\n새로고침 후 다른 시간을 선택해주세요.");
+                clearSelection();
+                modal.style.display = "none";
                 return;
             }
 
+            // ✅ 서버로 보낼 eqNo는 숫자면 Number로(백엔드가 숫자 기대하는 경우 대비)
+            const eqNoVal = /^\d+$/.test(eqNoRaw) ? Number(eqNoRaw) : eqNoRaw;
+
             const body = {
-                eqNo: eqNoVal,                               // ✅ 여기!
-                resvDate: currentDate.format("YYYY-MM-DD"),
-                startTime: start,                            // ✅ 변수 사용
-                endTime: end,                                // ✅ 변수 사용
+                eqNo: eqNoVal,
+                resvDate: dateStr,
+                startTime,
+                endTime,
                 purp: document.getElementById("purpose").value
             };
-
-            console.log("RESERVE BODY:", body); // 디버깅용
 
             const res = await apiFetch("/api/v1/shared-equipment-reservations", {
                 method: "POST",
@@ -778,8 +828,19 @@
             });
 
             if (!res.ok) {
-                const msg = await res.text();
-                alert("예약 실패: " + msg);
+                // ✅ text/json 둘 다 안전처리
+                let msg = "";
+                try {
+                    const errJson = await res.json();
+                    msg = errJson?.message || JSON.stringify(errJson);
+                } catch {
+                    msg = await res.text();
+                }
+
+                alert("예약 실패: " + (msg || "알 수 없는 오류"));
+
+                // ✅ 실패 시에도 최신화
+                await loadReservations();
                 return;
             }
 
@@ -816,6 +877,12 @@
             const row = dragCells[0].closest(".eq-row");
             const eqNo = row.dataset.eqNo;
 
+            // ✅ "null"/"undefined"/"" 방지
+            if (!eqNo || eqNo === "null" || eqNo === "undefined") {
+                alert("설비 식별자(eqNo)가 없습니다. 설비 목록 응답에 eqNo/id가 내려오는지 확인해주세요.");
+                return;
+            }
+
             // ✅ 왼쪽 라벨이 "설비명 (설비번호)"라서 그대로 쓰면 모달에도 같이 들어감
             const eqLabel = row.querySelector(".eq-name").innerText;
 
@@ -841,6 +908,16 @@
             modal.dataset.start = idxToTime(startIdx);
             modal.dataset.end = idxToTime(endIdx);
         };
+
+        // 30초마다 예약만 갱신
+        setInterval(() => {
+            loadReservations().catch(()=>{});
+        }, 30000);
+
+        // 탭 다시 활성화되면 갱신
+        document.addEventListener("visibilitychange", () => {
+            if (!document.hidden) loadReservations().catch(()=>{});
+        });
 
         /* ===== ME ===== */
         async function loadMe() {

--- a/src/main/resources/templates/reservation/sharedequipment/shared-equipment-reservation.html
+++ b/src/main/resources/templates/reservation/sharedequipment/shared-equipment-reservation.html
@@ -484,11 +484,17 @@
                 const row = document.createElement("div");
                 row.className = "eq-row";
 
-                // ✅ 예약 매칭은 resv.eqNo로 하므로 eqNo는 유지
-                row.dataset.eqNo = eq.eqNo;
+                // 1) eqNo 먼저 (예약 매칭에도 쓰니까)
+                const eqNo = pick(eq, ["eqNo", "sharedEquipmentNo", "equipmentNo"], null);
+                row.dataset.eqNo = eqNo ?? "";
 
-                // ✅ 표시용 설비번호(eqId) - API에 따라 eqId/id/eqNo 중 하나일 수 있어 안전하게
-                const eqId = pick(eq, ["eqId", "equipmentId", "id", "eqNo"], "-");
+                // 2) eqId는 eqNo를 fallback으로 (절대 eqId 자기 자신 쓰지 말기)
+                const eqId = pick(eq, ["eqId", "equipmentId", "id"], eqNo ?? "-");
+                row.dataset.eqId = eqId;
+
+                // 3) 이름도 안전하게
+                const eqName = pick(eq, ["eqName", "name"], "-");
+                row.dataset.eqName = eqName;
 
                 // ✅ 왼쪽 라벨: 설비명 + 설비번호(eqId)
                 row.innerHTML = `<div class="eq-name">${eq.eqName} (${eqId})</div>`;
@@ -692,8 +698,14 @@
 
             cancelBtn.innerText = "닫기";
 
-            const eqName = pick(resv, ["eqName", "sharedEquipmentName", "eq.eqName"], "-");
-            const eqId   = pick(resv, ["eqId", "equipmentId", "eq.eqId", "eqNo", "sharedEquipmentNo", "eq.eqNo"], "-"); // ✅
+            const eqNo = pick(resv, ["eqNo", "sharedEquipmentNo", "eq.eqNo"], null);
+
+            const row = eqNo ? document.querySelector(`.eq-row[data-eq-no="${eqNo}"]`) : null;
+            const fallbackEqId = row?.dataset?.eqId
+                ?? pick(EQUIPMENT.find(e => String(e.eqNo) === String(eqNo)) || {}, ["eqId","equipmentId","id"], "-");
+
+            const eqName = pick(resv, ["eqName", "sharedEquipmentName", "eq.eqName"], row?.dataset?.eqName ?? "-");
+            const eqId   = pick(resv, ["eqId", "equipmentId", "eq.eqId"], fallbackEqId);
             const resvDate = pick(resv, ["resvDate", "date"], resv.startedAt ? String(resv.startedAt).substring(0, 10) : "-");
 
             const startRaw = pick(resv, ["startTime"], resv.startedAt ? String(resv.startedAt).substring(11, 19) : null);
@@ -727,13 +739,37 @@
         cancelBtn.onclick = () => { modal.style.display = "none"; };
 
         reserveBtn.onclick = async () => {
+            const eqNoRaw = modal.dataset.eqNo;     // 문자열 그대로
+            const start = modal.dataset.start;
+            const end = modal.dataset.end;
+
+            if (!eqNoRaw) {
+                alert("설비 식별자(eqNo)가 없습니다. 설비 목록 응답에 eqNo/id가 내려오는지 확인해주세요.");
+                return;
+            }
+            if (!start || !end) {
+                alert("예약 시간이 설정되지 않았습니다. 시간을 다시 선택해주세요.");
+                return;
+            }
+
+            // ✅ 숫자면 Number로, 아니면 문자열 그대로
+            const eqNoVal = /^\d+$/.test(eqNoRaw) ? Number(eqNoRaw) : eqNoRaw;
+
+            // (추가 안전장치) 숫자로 변환했는데 NaN이면 막기
+            if (typeof eqNoVal === "number" && Number.isNaN(eqNoVal)) {
+                alert("설비 식별자(eqNo)가 올바르지 않습니다: " + eqNoRaw);
+                return;
+            }
+
             const body = {
-                eqNo: Number(modal.dataset.eqNo),
+                eqNo: eqNoVal,                               // ✅ 여기!
                 resvDate: currentDate.format("YYYY-MM-DD"),
-                startTime: modal.dataset.start,
-                endTime: modal.dataset.end,
+                startTime: start,                            // ✅ 변수 사용
+                endTime: end,                                // ✅ 변수 사용
                 purp: document.getElementById("purpose").value
             };
+
+            console.log("RESERVE BODY:", body); // 디버깅용
 
             const res = await apiFetch("/api/v1/shared-equipment-reservations", {
                 method: "POST",


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #412 

## 📝 작업 내용
-(관리자 삭제 로그) 이후 날짜가 이전 날짜보다 더 빠를 수 없는거 적용
-(관리자 삭제 로그) 페이징 오류
-(휴지통) 관리자 영구 삭제 버튼 활성화하게 하
-(내 예약 확인) 공유 설비에 예약 목적 뜨게하기
-(공유설비 예약) 예약된거 눌렀을때 설비번호가 표시안됨
-(법인차량 예약) 예약된거 눌렀을때 차량번호가 표시안됨
-(회의실/법인차량/공유설비 예약) 예약할때 동시 예약되면 프론트에서 빠르게 새로고침하고, 알림
-(공유함/개인함) 파일 확장자를 바꿨을때 경고알림표시
-(휴지통) 폴더 영구삭제할 수 있게하기
-(휴지통) 공유함 휴지통에서 영구삭제는 관리자와 업로더/폴더 생성자만 할 수 있게 수정
-(휴지통) 공유함 휴지통에서 복원은 부서 전체 사원이 할 수 있게 수정
 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
