### PR TITLE
fix : 사용자 뒷담 못보게 서비스 수정

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/dto/ResChatRoomListDto.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/dto/ResChatRoomListDto.java
@@ -1,10 +1,12 @@
 package com.multi.mlpenterpriseapprovalsystem.chat.dto;
+
 import com.multi.mlpenterpriseapprovalsystem.chat.domain.ChatRoom;
 import com.multi.mlpenterpriseapprovalsystem.chat.domain.ChatRoomMember;
 import com.multi.mlpenterpriseapprovalsystem.chat.domain.RoomType;
 import com.multi.mlpenterpriseapprovalsystem.employee.domain.Employee;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -17,6 +19,7 @@ import java.util.List;
  * @since : 2025. 12. 17. 수요일
  */
 @Getter
+@Setter
 @AllArgsConstructor
 public class ResChatRoomListDto {
 

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/service/ChatRoomService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/chat/service/ChatRoomService.java
@@ -133,11 +133,33 @@ public class ChatRoomService {
      * 내 채팅방 목록 조회 (무한 스크롤)
      *
      */
+// ChatRoomService.java 수정 제안
+
     @Transactional(readOnly = true)
     public List<ResChatRoomListDto> getMyRooms(String keyword, LocalDateTime cursor, Pageable pageable, String empId) {
         return chatRoomRepository.findMyRooms(empId, keyword, cursor, pageable)
                 .stream()
-                .map(room -> ResChatRoomListDto.from(room, empId))
+                .map(room -> {
+                    // 1. 현재 사용자의 멤버 정보(입장 시간 포함)를 가져옴
+                    ChatRoomMember me = room.getMembers().stream()
+                            .filter(m -> m.getEmployee().getEmpId().equals(empId))
+                            .findFirst()
+                            .orElse(null);
+
+                    ResChatRoomListDto dto = ResChatRoomListDto.from(room, empId);
+
+                    // 2. 방의 마지막 메시지 시간이 나의 재입장(joinedAt) 시간보다 이전이라면?
+                    // (주의: ChatRoomMember에 입장 시간 필드명이 joinedAt이라고 가정)
+                    if (me != null && room.getLastMessageAt() != null &&
+                            room.getLastMessageAt().isBefore(me.getJoinedAt())) {
+
+                        // 목록에 표시될 메시지 내용을 초기화
+                        dto.setLastMessage("새로운 대화를 시작해보세요.");
+                        dto.setLastMessageAt(null);
+                        dto.setUnreadCount(0);
+                    }
+                    return dto;
+                })
                 .collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #450

## 📝 작업 내용
- 채팅방 나가기 한 사용자가 나간 뒤 채팅 있으면 다시 초대됐을떄 채팅방 목록에서 그 이전 메세지 보이던 거 수정
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
