### PR TITLE
feat : 사내 규정 등록 완료시 사원 전체에게 규정 등록 알림 가는 거 비동기로 변경

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/config/AsyncConfig.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/common/config/AsyncConfig.java
@@ -1,7 +1,11 @@
 package com.multi.mlpenterpriseapprovalsystem.common.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
 
 /**
  * 비동기 설정 config
@@ -13,4 +17,13 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableAsync
 @Configuration
 public class AsyncConfig {
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+        ex.setCorePoolSize(4);
+        ex.setMaxPoolSize(8);
+        ex.setQueueCapacity(100);
+        ex.initialize();
+        return ex;
+    }
 }

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/event/ProvDocumentApprovedEvent.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/event/ProvDocumentApprovedEvent.java
@@ -1,0 +1,16 @@
+package com.multi.mlpenterpriseapprovalsystem.provdocument.event;
+
+/**
+ * 알림 비동기 전송 이벤트
+ *
+ * @author : 김승기
+ * @filename : ProvDocumentApprovedEvent
+ * @since : 2026. 1. 17. 토요일
+ */
+public record ProvDocumentApprovedEvent(
+        Long provNo,
+        String docTitle,
+        String comId
+) {
+
+}

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/service/ProvDocumentService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/service/ProvDocumentService.java
@@ -16,6 +16,7 @@ import com.multi.mlpenterpriseapprovalsystem.notification.domain.NotificationTyp
 import com.multi.mlpenterpriseapprovalsystem.notification.service.NotificationService;
 import com.multi.mlpenterpriseapprovalsystem.provdocument.domain.ProvDocument;
 import com.multi.mlpenterpriseapprovalsystem.provdocument.dto.*;
+import com.multi.mlpenterpriseapprovalsystem.provdocument.event.ProvDocumentApprovedEvent;
 import com.multi.mlpenterpriseapprovalsystem.provdocument.event.ProvEmbeddingRequestedEvent;
 import com.multi.mlpenterpriseapprovalsystem.provdocument.repository.ProvDocumentRepository;
 import lombok.RequiredArgsConstructor;
@@ -48,8 +49,8 @@ public class ProvDocumentService {
     private final AttachmentServiceImpl attachmentService;
     private final AttachmentRepository attachmentRepository;
     private final EmployeeRepository employeeRepository;
-    private final NotificationService notificationService;
     private final ApplicationEventPublisher publisher;
+    private final ProvNotificationService provNotificationService;
 
     @Transactional
     public Long create(String comId, ReqProvDocumentCreateDto req) {
@@ -231,14 +232,10 @@ public class ProvDocumentService {
         }
 
         doc.markDone(request.getChunkCnt() == null ? 0 : request.getChunkCnt());
-        String comId=doc.getCompany().getComId();
-
-        List<Employee> emps = employeeRepository.findAllByCompany_ComId(comId);
-        if (doc.getIsPublic()==Boolean.TRUE){
-            for(Employee emp : emps) {
-                notificationService.sendNotification(emp, NotificationType.OTHER, "챗봇 사용 가능 알림", "이제부터\""+doc.getDocTitle()+"\" 에 대한 질의를 챗봇에서 사용할 수 있습니다.","/employees");
-            }
+        if (Boolean.TRUE.equals(doc.getIsPublic())) {
+            publisher.publishEvent(new ProvDocumentApprovedEvent(doc.getProvNo(), doc.getDocTitle(), doc.getCompany().getComId()));
         }
+
         return doc.getProvNo();
     }
 

--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/service/ProvNotificationService.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/provdocument/service/ProvNotificationService.java
@@ -1,0 +1,43 @@
+package com.multi.mlpenterpriseapprovalsystem.provdocument.service;
+
+import com.multi.mlpenterpriseapprovalsystem.employee.domain.Employee;
+import com.multi.mlpenterpriseapprovalsystem.employee.repository.EmployeeRepository;
+import com.multi.mlpenterpriseapprovalsystem.notification.domain.NotificationType;
+import com.multi.mlpenterpriseapprovalsystem.notification.service.NotificationService;
+import com.multi.mlpenterpriseapprovalsystem.provdocument.event.ProvDocumentApprovedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.List;
+
+/**
+ * 알림 비동기 전송 서비스
+ *
+ * @author : 김승기
+ * @filename : ProvNotificationService
+ * @since : 2026. 1. 17. 토요일
+ */
+@Service
+@RequiredArgsConstructor
+public class ProvNotificationService {
+    private final NotificationService notificationService;
+    private final EmployeeRepository employeeRepository;
+
+    @Async("taskExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDocApprovedEvent(ProvDocumentApprovedEvent event) {
+        List<Employee> emps = employeeRepository.findAllByCompany_ComId(event.comId());
+
+        for (Employee emp : emps) {
+            notificationService.sendNotification(
+                    emp, NotificationType.OTHER,
+                    "챗봇 사용 가능 알림",
+                    "이제부터 \"" + event.docTitle() + "\" 에 대한 질의를 챗봇에서 사용할 수 있습니다.",
+                    "/employees"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #이슈번호

## 📝 작업 내용
- feat : 사내 규정 등록 완료시 사원 전체에게 규정 등록 알림 가는 거 비동기로 변경
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
