### PR TITLE
fix: 타 기기 로그인 감지 알림 오류 관련 로그 찍어보기(subscriber log.warn)

### DIFF
--- a/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/RedisLoginDetectSubscriber.java
+++ b/src/main/java/com/multi/mlpenterpriseapprovalsystem/notification/redis/RedisLoginDetectSubscriber.java
@@ -3,6 +3,7 @@ package com.multi.mlpenterpriseapprovalsystem.notification.redis;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.multi.mlpenterpriseapprovalsystem.common.sse.SseManager;
 import com.multi.mlpenterpriseapprovalsystem.notification.dto.NewLoginRedisMessage;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.connection.MessageListener;
@@ -20,6 +21,7 @@ import java.util.Map;
  * @since : 2026. 1. 10. 토요일
  */
 @Component
+@Slf4j
 public class RedisLoginDetectSubscriber implements MessageListener {
 
     private final ObjectMapper objectMapper;
@@ -37,10 +39,19 @@ public class RedisLoginDetectSubscriber implements MessageListener {
     public void onMessage(Message message, byte[] pattern) {
         String raw = new String(message.getBody(), StandardCharsets.UTF_8);
 
+        String channel = new String(message.getChannel(), StandardCharsets.UTF_8);
+
+        log.warn("[LOGIN-DETECT SUB] channel={}, pattern={}, raw={}",
+                channel,
+                pattern == null ? null : new String(pattern, StandardCharsets.UTF_8),
+                raw);
+
+
         final NewLoginRedisMessage msg;
         try {
             msg = objectMapper.readValue(raw, NewLoginRedisMessage.class);
         } catch (Exception e) {
+            log.warn("[LOGIN-DETECT SUB] parse failed: {}", e.toString());
             return;
         }
 
@@ -48,6 +59,9 @@ public class RedisLoginDetectSubscriber implements MessageListener {
         payload.put("message", "같은 계정으로 새 로그인이 감지되었습니다.");
         payload.put("ip", msg.getIp());
         payload.put("at", msg.getAt());
+
+        log.warn("[LOGIN-DETECT SUB] send empId={}, excludeDeviceId={}, event=new-login",
+                msg.getEmpId(), msg.getDeviceId());
 
         // ✅ 새 로그인 기기 제외, 나머지 기존 기기들만
         sseManager.sendToOtherDevices(msg.getEmpId(), msg.getDeviceId(), "new-login", payload);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #479

## 📝 작업 내용
- 타 기기 로그인 감지 알림 오류 관련 로그 찍어보기(subscriber log.warn)
- 
- 

## 체크리스트
- [ ] 포메팅이 적용되었습니다.

## 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
